### PR TITLE
Add image matching support to CLI and upgrade SourceAFIS

### DIFF
--- a/CLI/build.gradle
+++ b/CLI/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.machinezoo.sourceafis:sourceafis:3.8.1'
+    implementation 'com.machinezoo.sourceafis:sourceafis:3.17.1'
     implementation 'commons-codec:commons-codec:1.14'
     implementation platform('org.jetbrains.kotlin:kotlin-bom')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'

--- a/CLI/src/main/kotlin/uk/ac/lshtm/keppel/cli/MatchCommand.kt
+++ b/CLI/src/main/kotlin/uk/ac/lshtm/keppel/cli/MatchCommand.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.double
 import java.io.File
+import java.nio.file.Paths
 
 class MatchCommand(
         private val matcher: Matcher,
@@ -15,6 +16,7 @@ class MatchCommand(
         help = "Match two hex encoded ISO fingerprint templates. Threshold used for matching is $defaultThreshold.") {
 
     private val plainText by option("-p", help = Strings.PLAIN_TEXT_HELP).flag(default = false)
+    private val image by option("-i", help = Strings.PLAIN_TEXT_HELP).flag(default = false)
     private val matchWithScore by option("-ms", help = Strings.MATCH_WITH_SCORE_HELP).flag(default = false)
     private val matchWithoutScore by option("-m", help = Strings.MATCH_WITHOUT_SCORE_HELP).flag(default = false)
     private val threshold by option("-t", help = Strings.THRESHOLD_HELP).double()
@@ -23,13 +25,17 @@ class MatchCommand(
     private val templateTwo by argument(name = "TEMPLATE_TWO")
 
     override fun run() {
-        val (templateOne, templateTwo) = if (plainText) {
-            Pair(templateOne.toByteArray(), templateTwo.toByteArray())
+        val score = if (image) {
+            matcher.matchImage(Paths.get(templateOne), Paths.get(templateTwo))
         } else {
-            Pair(readAndTrim(File(templateOne)), readAndTrim(File(templateTwo)))
+            val (templateOne, templateTwo) = if (plainText) {
+                Pair(templateOne.toByteArray(), templateTwo.toByteArray())
+            } else {
+                Pair(readAndTrim(File(templateOne)), readAndTrim(File(templateTwo)))
+            }
+            matcher.match(templateOne, templateTwo)
         }
 
-        val score = matcher.match(templateOne, templateTwo)
         if (matchWithScore) {
             if (isMatch(score)) {
                 logger.log("match_$score")

--- a/CLI/src/main/kotlin/uk/ac/lshtm/keppel/cli/Matcher.kt
+++ b/CLI/src/main/kotlin/uk/ac/lshtm/keppel/cli/Matcher.kt
@@ -1,6 +1,10 @@
 package uk.ac.lshtm.keppel.cli
 
-interface Matcher {
+import com.machinezoo.sourceafis.FingerprintTemplate
+import java.nio.file.Path
 
+interface Matcher {
+    fun matchImage(one: Path, two: Path): Double 
     fun match(one: ByteArray, two: ByteArray): Double
+    fun match(one: FingerprintTemplate, two: FingerprintTemplate): Double
 }

--- a/CLI/src/main/kotlin/uk/ac/lshtm/keppel/cli/SourceAFISMatcher.kt
+++ b/CLI/src/main/kotlin/uk/ac/lshtm/keppel/cli/SourceAFISMatcher.kt
@@ -1,17 +1,31 @@
 package uk.ac.lshtm.keppel.cli
 
-import com.machinezoo.sourceafis.FingerprintCompatibility.convert
+import com.machinezoo.sourceafis.FingerprintCompatibility.importTemplate
+import com.machinezoo.sourceafis.FingerprintImage
 import com.machinezoo.sourceafis.FingerprintMatcher
+import com.machinezoo.sourceafis.FingerprintTemplate
 import org.apache.commons.codec.binary.Hex
+import java.nio.file.Path
+import java.nio.file.Files
 
 class SourceAFISMatcher : Matcher {
 
-    override fun match(one: ByteArray, two: ByteArray): Double {
-        val oneTemplate = convert(Hex.decodeHex(String(one)))
-        val twoTemplate = convert(Hex.decodeHex(String(two)))
+    override fun matchImage(one: Path, two: Path): Double {
+        val oneTemplate = FingerprintTemplate(FingerprintImage(Files.readAllBytes(one)))
+        val twoTemplate = FingerprintTemplate(FingerprintImage(Files.readAllBytes(two)))
 
-        return FingerprintMatcher()
-                .index(oneTemplate)
-                .match(twoTemplate)
+        return match(oneTemplate, twoTemplate)
+    }
+
+    override fun match(one: ByteArray, two: ByteArray): Double {
+        val oneTemplate = importTemplate(Hex.decodeHex(String(one)))
+        val twoTemplate = importTemplate(Hex.decodeHex(String(two)))
+
+        return match(oneTemplate, twoTemplate)
+    }
+
+    override fun match(one: FingerprintTemplate, two: FingerprintTemplate): Double {
+        return FingerprintMatcher(one)
+                .match(two)
     }
 }

--- a/README.md
+++ b/README.md
@@ -151,7 +151,20 @@ foo@bar:~$ keppel match -p 464d520020323000000001080000013c016200c500c5... 464d5
 
 15.386568130470566
 ```
-  
+
+**-i**         
+Treats TEMPLATE_ONE and TEMPLATE_TWO as two image files (PNG, JPEG, WSQ, etc.)
+This option is very useful for testing images directly without needing to convert
+to templates first.
+
+Example
+
+```console
+foo@bar:~$ keppel match -i one.wsq two.wsq
+
+15.386568130470566
+```
+
 **-ms**     
 Return whether templates match along with score like "match_210.124"
 


### PR DESCRIPTION
We found this was useful for testing purposes, but it's unlikely to be used in production settings due to the expense of converting the images to templates with each call. Also, we upgraded SourceAFIS to the latest version and fixed some deprecation warnings.

- [x] Adds `-i` CLI option to support comparing images directly (in any format supported by SourceAFIS).
- [x] Upgrades `sourceafis:3.17.1`