### PR TITLE
Show error when non hex encoded template is passed to MATCH

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -79,6 +79,10 @@ android {
     packagingOptions {
         pickFirst '**/*.so'
     }
+
+    lintOptions {
+        disable 'MissingTranslation'
+    }
 }
 
 dependencies {

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -4,6 +4,10 @@ import android.app.Activity
 import android.content.Intent
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -37,7 +41,7 @@ class MatchActionTest {
         )
 
         val intent = Intent(OdkExternal.ACTION_MATCH).also {
-            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, "blah".toHexString())
+            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
         }
         val scenario = rule.launchAction(intent)
 
@@ -51,6 +55,30 @@ class MatchActionTest {
         assertThat(
             extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),
             equalTo(96.0)
+        )
+    }
+
+    @Test
+    fun clickingMatch_whenExistingTemplateIsNotHexEncoded_showsAnError() {
+        val existingTemplate = "blah"
+
+        fakeMatcher.addScore(
+            existingTemplate,
+            fakeScanner.returnTemplate,
+            96.0
+        )
+
+        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate)
+        }
+        val scenario = rule.launchAction(intent)
+
+        onView(withText(R.string.match)).perform(click())
+        onView(withText(R.string.input_hex_error)).inRoot(isDialog()).check(matches(isDisplayed()))
+        onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
+        assertThat(
+            scenario.result.resultCode,
+            equalTo(Activity.RESULT_CANCELED)
         )
     }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -11,6 +11,7 @@ import uk.ac.lshtm.keppel.android.R
 import uk.ac.lshtm.keppel.android.databinding.ActivityScanBinding
 import uk.ac.lshtm.keppel.android.matcher
 import uk.ac.lshtm.keppel.android.scannerFactory
+import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState
 import uk.ac.lshtm.keppel.android.taskRunner
 import uk.ac.lshtm.keppel.core.Analytics
 import uk.ac.lshtm.keppel.core.CaptureResult
@@ -35,26 +36,22 @@ class ScanActivity : AppCompatActivity() {
 
         viewModel.scannerState.observe(this) { state ->
             when (state) {
-                ScannerState.DISCONNECTED -> {
+                ScannerState.Disconnected -> {
                     binding.connectProgressBar.visibility = View.VISIBLE
                     binding.captureButton.visibility = View.GONE
                     binding.captureProgressBar.visibility = View.GONE
                 }
 
-                ScannerState.CONNECTED -> {
+                ScannerState.Connected -> {
                     binding.connectProgressBar.visibility = View.GONE
                     binding.captureButton.visibility = View.VISIBLE
                     binding.captureProgressBar.visibility = View.GONE
                 }
 
-                ScannerState.SCANNING -> {
+                ScannerState.Scanning -> {
                     binding.connectProgressBar.visibility = View.GONE
                     binding.captureButton.visibility = View.GONE
                     binding.captureProgressBar.visibility = View.VISIBLE
-                }
-
-                else -> {
-                    // Ignore null case - not expected
                 }
             }
         }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import uk.ac.lshtm.keppel.android.OdkExternal
 import uk.ac.lshtm.keppel.android.R
 import uk.ac.lshtm.keppel.android.databinding.ActivityScanBinding
@@ -13,6 +14,7 @@ import uk.ac.lshtm.keppel.android.scannerFactory
 import uk.ac.lshtm.keppel.android.taskRunner
 import uk.ac.lshtm.keppel.core.Analytics
 import uk.ac.lshtm.keppel.core.CaptureResult
+import uk.ac.lshtm.keppel.core.fromHex
 
 class ScanActivity : AppCompatActivity() {
 
@@ -66,7 +68,17 @@ class ScanActivity : AppCompatActivity() {
 
         binding.captureButton.setOnClickListener {
             if (intent.action == OdkExternal.ACTION_MATCH) {
-                viewModel.capture(intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE))
+                val inputTemplate = intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE)
+                val decodedInputTemplate = inputTemplate!!.fromHex()
+
+                if (decodedInputTemplate != null) {
+                    viewModel.capture(decodedInputTemplate)
+                } else {
+                    MaterialAlertDialogBuilder(this)
+                        .setMessage(R.string.input_hex_error)
+                        .setPositiveButton(R.string.ok) { _, _ -> finish() }
+                        .show()
+                }
             } else {
                 viewModel.capture()
             }
@@ -99,11 +111,17 @@ class ScanActivity : AppCompatActivity() {
 
         if (inputIntent.extras?.containsKey(OdkExternal.PARAM_INPUT_VALUE) == false) {
             if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE)) {
-                intent.putExtra(inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE), capture.isoTemplate)
+                intent.putExtra(
+                    inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE),
+                    capture.isoTemplate
+                )
             }
 
             if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_NFIQ)) {
-                intent.putExtra(inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_NFIQ), capture.nfiq)
+                intent.putExtra(
+                    inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_NFIQ),
+                    capture.nfiq
+                )
             }
         } else {
             intent.putExtra(OdkExternal.PARAM_RETURN_VALUE, capture.isoTemplate)

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -35,13 +35,13 @@ class ScannerViewModel(
         }
     }
 
-    fun capture(inputTemplate: String? = null) {
+    fun capture(inputTemplate: ByteArray? = null) {
         _scannerState.value = SCANNING
 
         taskRunner.execute {
             val capture = scanner.capture()
             if (inputTemplate != null && capture != null) {
-                val score = matcher.match(inputTemplate.fromHex(), capture.isoTemplate.fromHex())
+                val score = matcher.match(inputTemplate, capture.isoTemplate.fromHex()!!)
                 _fingerData.postValue(Result.Match(score))
             } else if (capture != null) {
                 _fingerData.postValue(Result.Scan(capture))

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import uk.ac.lshtm.keppel.android.scanning.ScannerState.CONNECTED
-import uk.ac.lshtm.keppel.android.scanning.ScannerState.DISCONNECTED
-import uk.ac.lshtm.keppel.android.scanning.ScannerState.SCANNING
+import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState.Connected
+import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState.Disconnected
+import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState.Scanning
 import uk.ac.lshtm.keppel.core.CaptureResult
 import uk.ac.lshtm.keppel.core.Matcher
 import uk.ac.lshtm.keppel.core.Scanner
@@ -19,7 +19,7 @@ class ScannerViewModel(
     private val taskRunner: TaskRunner
 ) : ViewModel() {
 
-    private val _scannerState = MutableLiveData(DISCONNECTED)
+    private val _scannerState = MutableLiveData<ScannerState>(Disconnected)
     private val _result = MutableLiveData<Result?>(null)
 
     val scannerState: LiveData<ScannerState> = _scannerState
@@ -27,16 +27,16 @@ class ScannerViewModel(
 
     init {
         scanner.connect {
-            _scannerState.value = CONNECTED
+            _scannerState.value = Connected
         }
 
         scanner.onDisconnect {
-            _scannerState.value = DISCONNECTED
+            _scannerState.value = Disconnected
         }
     }
 
     fun capture(inputTemplate: String? = null) {
-        _scannerState.value = SCANNING
+        _scannerState.value = Scanning
 
         taskRunner.execute {
             val capture = scanner.capture()
@@ -54,7 +54,7 @@ class ScannerViewModel(
                 _result.postValue(null)
             }
 
-            _scannerState.postValue(CONNECTED)
+            _scannerState.postValue(Connected)
         }
     }
 
@@ -72,10 +72,12 @@ class ScannerViewModel(
         data class Match(val score: Double) : Result()
         object Error : Result()
     }
-}
 
-enum class ScannerState {
-    DISCONNECTED, CONNECTED, SCANNING
+    sealed class ScannerState {
+        object Disconnected : ScannerState()
+        object Connected : ScannerState()
+        object Scanning : ScannerState()
+    }
 }
 
 class ScannerViewModelFactory(

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -79,16 +79,3 @@ class ScannerViewModel(
         object Scanning : ScannerState()
     }
 }
-
-class ScannerViewModelFactory(
-    private val scanner: Scanner,
-    private val matcher: Matcher,
-    private val taskRunner: TaskRunner
-) :
-    ViewModelProvider.Factory {
-
-    @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        return ScannerViewModel(scanner, matcher, taskRunner) as T
-    }
-}

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="change_scanner">Change scanner</string>
     <string name="app_version">App version</string>
     <string name="match">Match</string>
+    <string name="input_hex_error">Input template is not hex encoded!</string>
+    <string name="ok">Ok</string>
 </resources>

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModelTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModelTest.kt
@@ -8,7 +8,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.*
-import org.robolectric.RobolectricTestRunner
+import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState
 import uk.ac.lshtm.keppel.core.Scanner
 import uk.ac.lshtm.keppel.core.TaskRunner
 
@@ -26,7 +26,7 @@ class ScannerViewModelTest {
 
         `when`(scanner.capture()).thenReturn(null)
         viewModel.capture()
-        assertThat(state.value, equalTo(ScannerState.CONNECTED))
+        assertThat(state.value, equalTo(ScannerState.Connected))
     }
 
     @Test

--- a/Android/core/src/main/java/uk/ac/lshtm/keppel/core/HexExtensions.kt
+++ b/Android/core/src/main/java/uk/ac/lshtm/keppel/core/HexExtensions.kt
@@ -1,5 +1,13 @@
 package uk.ac.lshtm.keppel.core
 
+import java.lang.NumberFormatException
+
 fun ByteArray.toHexString() = asUByteArray().joinToString("") { it.toString(16).padStart(2, '0') }
 fun String.toHexString() = this.toByteArray().toHexString()
-fun String.fromHex() = chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+fun String.fromHex(): ByteArray? {
+    try {
+        return chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+    } catch (e: NumberFormatException) {
+        return null
+    }
+}


### PR DESCRIPTION
An error message will now be shown if Collect passes a data that hasn't been hex encoded as the ISO template. Before this, the app would crash if that happened.