### PR TITLE
Return multiple results from MATCH

### DIFF
--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -7,7 +7,6 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -33,7 +32,6 @@ class MatchActionTest {
     @Test
     fun clickingMatch_capturesAndReturnsMatchScore() {
         val existingTemplate = "blah"
-
         fakeMatcher.addScore(
             existingTemplate,
             fakeScanner.returnTemplate,
@@ -41,6 +39,7 @@ class MatchActionTest {
         )
 
         val intent = Intent(OdkExternal.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
             it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
         }
         val scenario = rule.launchAction(intent)
@@ -61,7 +60,6 @@ class MatchActionTest {
     @Test
     fun clickingMatch_whenExistingTemplateIsNotHexEncoded_showsAnError() {
         val existingTemplate = "blah"
-
         fakeMatcher.addScore(
             existingTemplate,
             fakeScanner.returnTemplate,
@@ -69,6 +67,7 @@ class MatchActionTest {
         )
 
         val intent = Intent(OdkExternal.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
             it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate)
         }
         val scenario = rule.launchAction(intent)
@@ -80,5 +79,40 @@ class MatchActionTest {
             scenario.result.resultCode,
             equalTo(Activity.RESULT_CANCELED)
         )
+    }
+
+    @Test
+    fun clickingMatch_whenReturnValuesSpecified_capturesAndReturnsThoseValues() {
+        val existingTemplate = "blah"
+        fakeMatcher.addScore(
+            existingTemplate,
+            fakeScanner.returnTemplate,
+            96.0
+        )
+
+        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
+            it.putExtra(OdkExternal.PARAM_RETURN_SCORE, "my_score")
+            it.putExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
+            it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
+        }
+        val scenario = rule.launchAction(intent)
+
+        onView(withText(R.string.match)).perform(click())
+        assertThat(
+            scenario.result.resultCode,
+            equalTo(Activity.RESULT_OK)
+        )
+
+        val extras = scenario.result.resultData.extras!!
+        assertThat(
+            extras.getDouble("my_score"),
+            equalTo(96.0)
+        )
+        assertThat(
+            extras.getString("my_iso_template"),
+            equalTo(fakeScanner.returnTemplate.toHexString())
+        )
+        assertThat(extras.getInt("my_nfiq"), equalTo(17))
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -41,7 +41,7 @@ class ScanActionTest {
     }
 
     @Test
-    fun clickingCapture_whenReturnValuesSpecified_capturesAndReturnsThoseValues_fromScanner() {
+    fun clickingCapture_whenReturnValuesSpecified_capturesAndReturnsThoseValues() {
         val intent = Intent(OdkExternal.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
             it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
@@ -55,20 +55,6 @@ class ScanActionTest {
             extras.get("my_iso_template"),
             equalTo("ISO TEMPLATE".toHexString())
         )
-        assertThat(extras.get("my_nfiq"), equalTo(17))
-    }
-
-    @Test
-    fun clickingCapture_whenOnlyOneReturnValueSpecified_capturesAndReturnsThatValue_fromScanner() {
-        val intent = Intent(OdkExternal.ACTION_SCAN).also {
-            it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
-        }
-        val scenario = rule.launchAction(intent)
-
-        onView(withText(R.string.capture)).perform(click())
-        assertThat(scenario.result.resultCode, equalTo(Activity.RESULT_OK))
-        val extras = scenario.result.resultData.extras!!
-        assertThat(extras.size(), equalTo(1))
         assertThat(extras.get("my_nfiq"), equalTo(17))
     }
 

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
@@ -1,5 +1,7 @@
 package uk.ac.lshtm.keppel.android
 
+import android.content.Intent
+
 object OdkExternal {
     const val PARAM_INPUT_VALUE = "value"
     const val PARAM_RETURN_VALUE = "value"
@@ -11,5 +13,22 @@ object OdkExternal {
 
     const val PARAM_RETURN_ISO_TEMPLATE = "$APP_ID.return_iso_template"
     const val PARAM_RETURN_NFIQ = "$APP_ID.return_nfiq"
+    const val PARAM_RETURN_SCORE = "$APP_ID.return_score"
     const val PARAM_ISO_TEMPLATE = "$APP_ID.iso_template"
+
+    fun isSingleReturn(intent: Intent): Boolean {
+        return intent.extras?.containsKey(PARAM_INPUT_VALUE) == true
+    }
+
+    fun buildSingleReturnIntent(double: Double): Intent {
+        return Intent().also {
+            it.putExtra(PARAM_RETURN_VALUE, double)
+        }
+    }
+
+    fun buildSingleReturnIntent(string: String): Intent {
+        return Intent().also {
+            it.putExtra(PARAM_RETURN_VALUE, string)
+        }
+    }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
@@ -31,4 +31,20 @@ object OdkExternal {
             it.putExtra(PARAM_RETURN_VALUE, string)
         }
     }
+
+    fun buildMultipleReturnResult(inputIntent: Intent, results: Map<String, Any>): Intent {
+        return Intent().also {
+            results.forEach { (key, value) ->
+                if (inputIntent.hasExtra(key)) {
+                    val returnExtra = inputIntent.getStringExtra(key)
+
+                    when (value) {
+                        is Double -> it.putExtra(returnExtra, value)
+                        is Int -> it.putExtra(returnExtra, value)
+                        else -> it.putExtra(returnExtra, value as String)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -113,44 +113,30 @@ class ScanActivity : AppCompatActivity() {
         return if (OdkExternal.isSingleReturn(inputIntent)) {
             OdkExternal.buildSingleReturnIntent(capture.isoTemplate)
         } else {
-            Intent().also {
-                if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE)) {
-                    it.putExtra(
-                        inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE),
-                        capture.isoTemplate
-                    )
-                }
-
-                if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_NFIQ)) {
-                    it.putExtra(
-                        inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_NFIQ),
-                        capture.nfiq
-                    )
-                }
-            }
+            OdkExternal.buildMultipleReturnResult(
+                inputIntent, mapOf(
+                    OdkExternal.PARAM_RETURN_ISO_TEMPLATE to capture.isoTemplate,
+                    OdkExternal.PARAM_RETURN_NFIQ to capture.nfiq
+                )
+            )
         }
     }
 
-    private fun buildMatchReturn(inputIntent: Intent, score: Double, capture: CaptureResult): Intent {
+    private fun buildMatchReturn(
+        inputIntent: Intent,
+        score: Double,
+        capture: CaptureResult
+    ): Intent {
         return if (OdkExternal.isSingleReturn(inputIntent)) {
             OdkExternal.buildSingleReturnIntent(score)
         } else {
-            Intent().also {
-                it.putExtra(
-                    inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_SCORE),
-                    score
+            OdkExternal.buildMultipleReturnResult(
+                inputIntent, mapOf(
+                    OdkExternal.PARAM_RETURN_SCORE to score,
+                    OdkExternal.PARAM_RETURN_ISO_TEMPLATE to capture.isoTemplate,
+                    OdkExternal.PARAM_RETURN_NFIQ to capture.nfiq
                 )
-
-                it.putExtra(
-                    inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE),
-                    capture.isoTemplate
-                )
-
-                it.putExtra(
-                    inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_NFIQ),
-                    capture.nfiq
-                )
-            }
+            )
         }
     }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -87,7 +87,7 @@ class ScanActivity : AppCompatActivity() {
     private fun processResult(result: ScannerViewModel.Result) {
         when (result) {
             is ScannerViewModel.Result.Match -> {
-                returnResult(buildMatchReturn(result.score))
+                returnResult(buildMatchReturn(this.intent, result.score, result.captureResult))
             }
 
             is ScannerViewModel.Result.Scan -> {
@@ -110,31 +110,47 @@ class ScanActivity : AppCompatActivity() {
     }
 
     private fun buildScanReturn(inputIntent: Intent, capture: CaptureResult): Intent {
-        val intent = Intent()
+        return if (OdkExternal.isSingleReturn(inputIntent)) {
+            OdkExternal.buildSingleReturnIntent(capture.isoTemplate)
+        } else {
+            Intent().also {
+                if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE)) {
+                    it.putExtra(
+                        inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE),
+                        capture.isoTemplate
+                    )
+                }
 
-        if (inputIntent.extras?.containsKey(OdkExternal.PARAM_INPUT_VALUE) == false) {
-            if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE)) {
-                intent.putExtra(
+                if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_NFIQ)) {
+                    it.putExtra(
+                        inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_NFIQ),
+                        capture.nfiq
+                    )
+                }
+            }
+        }
+    }
+
+    private fun buildMatchReturn(inputIntent: Intent, score: Double, capture: CaptureResult): Intent {
+        return if (OdkExternal.isSingleReturn(inputIntent)) {
+            OdkExternal.buildSingleReturnIntent(score)
+        } else {
+            Intent().also {
+                it.putExtra(
+                    inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_SCORE),
+                    score
+                )
+
+                it.putExtra(
                     inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE),
                     capture.isoTemplate
                 )
-            }
 
-            if (inputIntent.hasExtra(OdkExternal.PARAM_RETURN_NFIQ)) {
-                intent.putExtra(
+                it.putExtra(
                     inputIntent.getStringExtra(OdkExternal.PARAM_RETURN_NFIQ),
                     capture.nfiq
                 )
             }
-        } else {
-            intent.putExtra(OdkExternal.PARAM_RETURN_VALUE, capture.isoTemplate)
         }
-
-        return intent
-    }
-
-    private fun buildMatchReturn(score: Double): Intent {
-        intent.putExtra(OdkExternal.PARAM_RETURN_VALUE, score)
-        return intent
     }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -44,7 +44,7 @@ class ScannerViewModel(
                 val decodedInputTemplate = inputTemplate.fromHex()
                 if (decodedInputTemplate != null) {
                     val score = matcher.match(decodedInputTemplate, capture.isoTemplate.fromHex()!!)
-                    _result.postValue(Result.Match(score))
+                    _result.postValue(Result.Match(score, capture))
                 } else {
                     _result.postValue(Result.Error)
                 }
@@ -69,7 +69,7 @@ class ScannerViewModel(
 
     sealed class Result {
         data class Scan(val captureResult: CaptureResult) : Result()
-        data class Match(val score: Double) : Result()
+        data class Match(val score: Double, val captureResult: CaptureResult) : Result()
         object Error : Result()
     }
 

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/OdkExternalTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/OdkExternalTest.kt
@@ -1,0 +1,49 @@
+package uk.ac.lshtm.keppel.android
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OdkExternalTest {
+
+    @Test
+    fun `buildMultipleReturnResult does not include result when key is not in input intent`() {
+        val inputIntent = Intent().also {
+            it.putExtra("my_return_param", "my_return_field")
+        }
+        val results =
+            mapOf("my_return_param" to "result", "my_other_return_param" to "other result")
+        val intent =
+            OdkExternal.buildMultipleReturnResult(inputIntent, results)
+        assertThat(intent.extras!!.size(), equalTo(1))
+        assertThat(intent.extras!!.getString("my_return_field"), equalTo("result"))
+    }
+
+    @Test
+    fun `buildMultipleReturnResult can include double results`() {
+        val inputIntent = Intent().also {
+            it.putExtra("my_return_param", "my_return_field")
+        }
+        val results =
+            mapOf("my_return_param" to 12.0)
+        val intent =
+            OdkExternal.buildMultipleReturnResult(inputIntent, results)
+        assertThat(intent.extras!!.getDouble("my_return_field"), equalTo(12.0))
+    }
+
+    @Test
+    fun `buildMultipleReturnResult can include int results`() {
+        val inputIntent = Intent().also {
+            it.putExtra("my_return_param", "my_return_field")
+        }
+        val results =
+            mapOf("my_return_param" to 12)
+        val intent =
+            OdkExternal.buildMultipleReturnResult(inputIntent, results)
+        assertThat(intent.extras!!.getInt("my_return_field"), equalTo(12))
+    }
+}


### PR DESCRIPTION
This allows the scanned ISO template and NFIQ to be returned along with the match score for the `MATCH` action.

For multiple results, the `body::intent` for a `MATCH` action would look like:

```
uk.ac.lshtm.keppel.android.MATCH(uk.ac.lshtm.keppel.android.iso_template=/data/finger_1, uk.ac.lshtm.keppel.android.return_iso_template="my_iso_template", uk.ac.lshtm.keppel.android.return_nfiq="my_nfiq", uk.ac.lshtm.keppel.android.return_score="my_score")
```

Here's an example form that scans a finger print and then matches, returning the template, the NFIQ and the score: [Multiple Match form.xlsx](https://github.com/LSHTM-ORK/ODK_Biometrics/files/14807054/Multiple.Match.form.xlsx).
