### PR TITLE
Ask for USB permissions when connecting devices

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -16,11 +16,18 @@
 
         <activity
             android:name="uk.ac.lshtm.keppel.android.settings.SettingsActivity"
+            android:directBootAware="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+
+            <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" android:resource="@xml/usb_device_filter" />
         </activity>
 
         <activity

--- a/Android/app/src/main/res/xml/usb_device_filter.xml
+++ b/Android/app/src/main/res/xml/usb_device_filter.xml
@@ -2,4 +2,7 @@
 <resources>
     <!-- BioMini Slim 3 -->
     <usb-device vendor-id="5841" product-id="1059"/>
+
+    <!-- Mantra MFS100 -->
+    <usb-device vendor-id="11279" product-id="4101"/>
 </resources>

--- a/Android/app/src/main/res/xml/usb_device_filter.xml
+++ b/Android/app/src/main/res/xml/usb_device_filter.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- BioMini Slim 3 -->
+    <usb-device vendor-id="5841" product-id="1059"/>
+</resources>


### PR DESCRIPTION
Connecting either supported scanner will now immediately open Keppel and request USB permission. Unlike the "on demand" permission request when connecting to the scanners, this will include a checkbox that (when ticked) will grant Keppel permission as the default app for the device and prevent it from needing to re-request permission the next time the device is restarted.

One caveat is that this prompt will happen on the next system boot on a device where the scanner is always connected (like on a BioRugged tablet).