### PR TITLE
Improve error handling for `MATCH`

### DIFF
--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ChangeScannerTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ChangeScannerTest.kt
@@ -2,11 +2,7 @@ package uk.ac.lshtm.keppel.android
 
 import androidx.preference.PreferenceManager.getDefaultSharedPreferences
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Rule
@@ -30,12 +26,9 @@ class ChangeScannerTest {
     @Test
     fun canChangeScanner() {
         rule.launchApp()
-
-        onView(withText("Scanner 1")).check(matches(isDisplayed()))
-        onView(withText(R.string.change_scanner)).perform(click())
-
-        onView(withText("Scanner 2")).perform(click())
-        onView(withText(R.string.app_name)).check(matches(isDisplayed()))
+            .assertTextDisplayed("Scanner 1")
+            .clickChangeScanner()
+            .changeScanner("Scanner 2")
 
         val scannerPref =
             getDefaultSharedPreferences(getApplicationContext<Keppel>()).getString("scanner", null)
@@ -45,10 +38,7 @@ class ChangeScannerTest {
     @Test
     fun unavailableScannersAreNotShown() {
         rule.launchApp()
-
-        onView(withText("Scanner 1")).check(matches(isDisplayed()))
-        onView(withText(R.string.change_scanner)).perform(click())
-
-        onView(withText("Unavailable")).check(doesNotExist())
+            .clickChangeScanner()
+            .assertNoScanner("Unavailable")
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -1,15 +1,7 @@
 package uk.ac.lshtm.keppel.android
 
 import android.app.Activity
-import android.app.Application
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.RootMatchers.isDialog
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Rule
@@ -18,6 +10,8 @@ import uk.ac.lshtm.keppel.android.support.FakeMatcher
 import uk.ac.lshtm.keppel.android.support.FakeScanner
 import uk.ac.lshtm.keppel.android.support.FakeScannerFactory
 import uk.ac.lshtm.keppel.android.support.KeppelTestRule
+import uk.ac.lshtm.keppel.android.support.pages.ErrorDialogPage
+import uk.ac.lshtm.keppel.android.support.pages.MatchPage
 import uk.ac.lshtm.keppel.core.toHexString
 
 class MatchActionTest {
@@ -38,15 +32,14 @@ class MatchActionTest {
             it.putExtra("blah", "blah")
         }
 
-        val scenario = rule.launchAction(intent)
+        val result = rule.launchAction(
+            intent,
+            ErrorDialogPage(R.string.input_missing_error, OdkExternal.PARAM_ISO_TEMPLATE)
+        ) {
+            it.clickOk()
+        }
 
-        val errorString = ApplicationProvider.getApplicationContext<Application>().getString(R.string.input_missing_error, OdkExternal.PARAM_ISO_TEMPLATE)
-        onView(withText(errorString)).inRoot(isDialog()).check(matches(isDisplayed()))
-        onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
-        assertThat(
-            scenario.result.resultCode,
-            equalTo(Activity.RESULT_CANCELED)
-        )
+        assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
     }
 
     @Test
@@ -62,15 +55,14 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
             it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
         }
-        val scenario = rule.launchAction(intent)
 
-        onView(withText(R.string.match)).perform(click())
-        assertThat(
-            scenario.result.resultCode,
-            equalTo(Activity.RESULT_OK)
-        )
+        val result = rule.launchAction(intent, MatchPage()) {
+            it.clickMatch()
+        }
 
-        val extras = scenario.result.resultData.extras!!
+        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+
+        val extras = result.resultData.extras!!
         assertThat(
             extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),
             equalTo(96.0)
@@ -90,15 +82,13 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
             it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate)
         }
-        val scenario = rule.launchAction(intent)
 
-        onView(withText(R.string.match)).perform(click())
-        onView(withText(R.string.input_hex_error)).inRoot(isDialog()).check(matches(isDisplayed()))
-        onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
-        assertThat(
-            scenario.result.resultCode,
-            equalTo(Activity.RESULT_CANCELED)
-        )
+        val result = rule.launchAction(intent, MatchPage()) {
+            it.clickMatch(ErrorDialogPage(R.string.input_hex_error))
+                .clickOk()
+        }
+
+        assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
     }
 
     @Test
@@ -116,23 +106,19 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
             it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
         }
-        val scenario = rule.launchAction(intent)
 
-        onView(withText(R.string.match)).perform(click())
-        assertThat(
-            scenario.result.resultCode,
-            equalTo(Activity.RESULT_OK)
-        )
+        val result = rule.launchAction(intent, MatchPage()) {
+            it.clickMatch()
+        }
 
-        val extras = scenario.result.resultData.extras!!
-        assertThat(
-            extras.getDouble("my_score"),
-            equalTo(96.0)
-        )
+        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+
+        val extras = result.resultData.extras!!
+        assertThat(extras.getDouble("my_score"), equalTo(96.0))
+        assertThat(extras.getInt("my_nfiq"), equalTo(17))
         assertThat(
             extras.getString("my_iso_template"),
             equalTo(fakeScanner.returnTemplate.toHexString())
         )
-        assertThat(extras.getInt("my_nfiq"), equalTo(17))
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -84,7 +84,29 @@ class MatchActionTest {
         }
 
         val result = rule.launchAction(intent, MatchPage()) {
-            it.clickMatch(ErrorDialogPage(R.string.input_hex_error))
+            it.clickMatch(ErrorDialogPage(R.string.input_format_error))
+                .clickOk()
+        }
+
+        assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
+    }
+
+    @Test
+    fun clickingMatch_whenMatchFails_showsAnError() {
+        val existingTemplate = "blah"
+        fakeMatcher.addScore(
+            existingTemplate,
+            fakeScanner.returnTemplate,
+            null
+        )
+
+        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
+            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
+        }
+
+        val result = rule.launchAction(intent, MatchPage()) {
+            it.clickMatch(ErrorDialogPage(R.string.input_format_error))
                 .clickOk()
         }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -1,7 +1,9 @@
 package uk.ac.lshtm.keppel.android
 
 import android.app.Activity
+import android.app.Application
 import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -28,6 +30,24 @@ class MatchActionTest {
         scanners = listOf(FakeScannerFactory(fakeScanner)),
         matcher = fakeMatcher
     )
+
+    @Test
+    fun whenNoTemplateIsSupplied_showsError() {
+        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
+            it.putExtra("blah", "blah")
+        }
+
+        val scenario = rule.launchAction(intent)
+
+        val errorString = ApplicationProvider.getApplicationContext<Application>().getString(R.string.input_missing_error, OdkExternal.PARAM_ISO_TEMPLATE)
+        onView(withText(errorString)).inRoot(isDialog()).check(matches(isDisplayed()))
+        onView(withText(R.string.ok)).inRoot(isDialog()).perform(click())
+        assertThat(
+            scenario.result.resultCode,
+            equalTo(Activity.RESULT_CANCELED)
+        )
+    }
 
     @Test
     fun clickingMatch_capturesAndReturnsMatchScore() {

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -2,9 +2,6 @@ package uk.ac.lshtm.keppel.android
 
 import android.app.Activity
 import android.content.Intent
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -14,6 +11,7 @@ import org.junit.runner.RunWith
 import uk.ac.lshtm.keppel.android.support.FakeScanner
 import uk.ac.lshtm.keppel.android.support.FakeScannerFactory
 import uk.ac.lshtm.keppel.android.support.KeppelTestRule
+import uk.ac.lshtm.keppel.android.support.pages.CapturePage
 import uk.ac.lshtm.keppel.core.toHexString
 
 @RunWith(AndroidJUnit4::class)
@@ -29,11 +27,13 @@ class ScanActionTest {
         val intent = Intent(OdkExternal.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
         }
-        val scenario = rule.launchAction(intent)
 
-        onView(withText(R.string.capture)).perform(click())
-        assertThat(scenario.result.resultCode, equalTo(Activity.RESULT_OK))
-        val extras = scenario.result.resultData.extras!!
+        val result = rule.launchAction(intent, CapturePage()) {
+            it.clickCapture()
+        }
+
+        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+        val extras = result.resultData.extras!!
         assertThat(
             extras.getString(OdkExternal.PARAM_RETURN_VALUE),
             equalTo("ISO TEMPLATE".toHexString())
@@ -46,11 +46,13 @@ class ScanActionTest {
             it.putExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
             it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
         }
-        val scenario = rule.launchAction(intent)
 
-        onView(withText(R.string.capture)).perform(click())
-        assertThat(scenario.result.resultCode, equalTo(Activity.RESULT_OK))
-        val extras = scenario.result.resultData.extras!!
+        val result = rule.launchAction(intent, CapturePage()) {
+            it.clickCapture()
+        }
+
+        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+        val extras = result.resultData.extras!!
         assertThat(
             extras.get("my_iso_template"),
             equalTo("ISO TEMPLATE".toHexString())
@@ -63,14 +65,16 @@ class ScanActionTest {
         val intent = Intent(OdkExternal.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
         }
-        val scenario = rule.launchAction(intent)
 
-        fakeScanner.neverCapture = true // Make sure we have a chance to hit "Cancel"
-        rule.waitForBackgroundTasks = false // Allow task to run while interacting with UI
-        onView(withText(R.string.capture)).perform(click())
-        onView(withText(R.string.cancel)).perform(click())
+        val result = rule.launchAction(intent, CapturePage()) {
+            fakeScanner.neverCapture = true // Make sure we have a chance to hit "Cancel"
+            rule.waitForBackgroundTasks = false // Allow task to run while interacting with UI
 
-        assertThat(scenario.result.resultCode, equalTo(Activity.RESULT_CANCELED))
-        assertThat(scenario.result.resultData, equalTo(null))
+            it.clickCapture()
+            it.clickCancel()
+        }
+
+        assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
+        assertThat(result.resultData, equalTo(null))
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/VersionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/VersionTest.kt
@@ -1,9 +1,5 @@
 package uk.ac.lshtm.keppel.android
 
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
@@ -19,6 +15,6 @@ class VersionTest {
     @Test
     fun canSeeAppVersion() {
         rule.launchApp()
-        onView(withText(BuildConfig.VERSION_NAME)).check(matches(isDisplayed()))
+            .assertTextDisplayed(BuildConfig.VERSION_NAME)
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Assertions.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Assertions.kt
@@ -1,0 +1,27 @@
+package uk.ac.lshtm.keppel.android.support
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Root
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import org.hamcrest.Matcher
+
+object Assertions {
+
+    fun assertTextDisplayed(text: String, root: Matcher<Root>? = null) {
+        if (root != null) {
+            onView(withText(text)).inRoot(root).check(matches(isDisplayed()))
+        } else {
+            onView(withText(text)).check(matches(isDisplayed()))
+        }
+    }
+
+    fun assertTextDisplayed(text: Int, vararg formatArgs: Any, root: Matcher<Root>? = null) {
+        val string =
+            ApplicationProvider.getApplicationContext<Application>().getString(text, *formatArgs)
+        assertTextDisplayed(string)
+    }
+}

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Assertions.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Assertions.kt
@@ -4,9 +4,11 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Root
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
 
 object Assertions {
@@ -22,6 +24,14 @@ object Assertions {
     fun assertTextDisplayed(text: Int, vararg formatArgs: Any, root: Matcher<Root>? = null) {
         val string =
             ApplicationProvider.getApplicationContext<Application>().getString(text, *formatArgs)
-        assertTextDisplayed(string)
+        assertTextDisplayed(string, root)
+    }
+
+    fun assertTextNotDisplayed(text: String, root: Matcher<Root>? = null) {
+        if (root != null) {
+            onView(withText(text)).inRoot(root).check(doesNotExist())
+        } else {
+            onView(withText(text)).check(doesNotExist())
+        }
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/FakeMatcher.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/FakeMatcher.kt
@@ -4,13 +4,18 @@ import uk.ac.lshtm.keppel.core.Matcher
 
 class FakeMatcher : Matcher {
 
-    private val matches = mutableMapOf<Pair<String, String>, Double>()
+    private val matches = mutableMapOf<Pair<String, String>, Double?>()
 
-    override fun match(one: ByteArray, two: ByteArray): Double {
-        return matches[Pair(String(one), String(two))] ?: 0.0
+    override fun match(one: ByteArray, two: ByteArray): Double? {
+        val key = Pair(String(one), String(two))
+        return if (matches.containsKey(key)) {
+            matches[key]
+        } else {
+            0.0
+        }
     }
 
-    fun addScore(one: String, two: String, score: Double) {
+    fun addScore(one: String, two: String, score: Double?) {
         matches[Pair(one, two)] = score
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Interactions.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Interactions.kt
@@ -1,0 +1,27 @@
+package uk.ac.lshtm.keppel.android.support
+
+import android.app.Application
+import androidx.annotation.StringRes
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Root
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import org.hamcrest.Matcher
+
+object Interactions {
+
+    fun clickOn(text: String, root: Matcher<Root>? = null) {
+        if (root != null) {
+            onView(withText(text)).inRoot(root).perform(click())
+        } else {
+            onView(withText(text)).perform(click())
+        }
+    }
+
+    fun clickOn(@StringRes text: Int, vararg formatArgs: Any, root: Matcher<Root>? = null) {
+        val string =
+            ApplicationProvider.getApplicationContext<Application>().getString(text, *formatArgs)
+        clickOn(string)
+    }
+}

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
@@ -1,6 +1,7 @@
 package uk.ac.lshtm.keppel.android.support
 
 import android.app.Activity
+import android.app.Instrumentation
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -10,6 +11,7 @@ import org.junit.rules.ExternalResource
 import uk.ac.lshtm.keppel.android.Keppel
 import uk.ac.lshtm.keppel.android.scanning.ScannerFactory
 import uk.ac.lshtm.keppel.android.settings.SettingsActivity
+import uk.ac.lshtm.keppel.android.support.pages.Page
 import uk.ac.lshtm.keppel.core.Matcher
 import uk.ac.lshtm.keppel.core.TaskRunner
 
@@ -19,7 +21,7 @@ class KeppelTestRule(
 ) : ExternalResource() {
 
     var waitForBackgroundTasks = true
-        set (value) {
+        set(value) {
             field = value
             taskRunnerIdlingResource.enabled = value
         }
@@ -28,7 +30,7 @@ class KeppelTestRule(
     private val taskRunnerIdlingResource = TaskRunnerIdlingResource(application.taskRunner)
 
     private var activityScenario: ActivityScenario<*>? = null
-        set (value) {
+        set(value) {
             if (field != null) {
                 throw IllegalStateException("ActivityScenario already launched!")
             }
@@ -61,6 +63,16 @@ class KeppelTestRule(
         return ActivityScenario.launchActivityForResult<Activity>(intent).also {
             activityScenario = it
         }
+    }
+
+    fun <T : Page<T>> launchAction(
+        intent: Intent,
+        page: T,
+        block: (T) -> Unit
+    ): Instrumentation.ActivityResult {
+        val scenario = launchAction(intent)
+        block(page.assert())
+        return scenario.result
     }
 }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
@@ -12,6 +12,7 @@ import uk.ac.lshtm.keppel.android.Keppel
 import uk.ac.lshtm.keppel.android.scanning.ScannerFactory
 import uk.ac.lshtm.keppel.android.settings.SettingsActivity
 import uk.ac.lshtm.keppel.android.support.pages.Page
+import uk.ac.lshtm.keppel.android.support.pages.SettingsPage
 import uk.ac.lshtm.keppel.core.Matcher
 import uk.ac.lshtm.keppel.core.TaskRunner
 
@@ -53,16 +54,12 @@ class KeppelTestRule(
         IdlingRegistry.getInstance().unregister(taskRunnerIdlingResource)
     }
 
-    fun launchApp() {
+    fun launchApp(): SettingsPage {
         ActivityScenario.launch(SettingsActivity::class.java).also {
             activityScenario = it
         }
-    }
 
-    fun launchAction(intent: Intent): ActivityScenario<Activity> {
-        return ActivityScenario.launchActivityForResult<Activity>(intent).also {
-            activityScenario = it
-        }
+        return SettingsPage().assert()
     }
 
     fun <T : Page<T>> launchAction(
@@ -73,6 +70,12 @@ class KeppelTestRule(
         val scenario = launchAction(intent)
         block(page.assert())
         return scenario.result
+    }
+
+    private fun launchAction(intent: Intent): ActivityScenario<Activity> {
+        return ActivityScenario.launchActivityForResult<Activity>(intent).also {
+            activityScenario = it
+        }
     }
 }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturePage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturePage.kt
@@ -1,0 +1,20 @@
+package uk.ac.lshtm.keppel.android.support.pages
+
+import uk.ac.lshtm.keppel.android.R
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.Interactions.clickOn
+
+class CapturePage : Page<CapturePage> {
+    override fun assert(): CapturePage {
+        assertTextDisplayed(R.string.capture)
+        return this
+    }
+
+    fun clickCapture() {
+        clickOn(R.string.capture)
+    }
+
+    fun clickCancel() {
+        clickOn(R.string.cancel)
+    }
+}

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/ErrorDialogPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/ErrorDialogPage.kt
@@ -1,0 +1,25 @@
+package uk.ac.lshtm.keppel.android.support.pages
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import uk.ac.lshtm.keppel.android.R
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.Interactions.clickOn
+
+class ErrorDialogPage(private val text: String) : Page<ErrorDialogPage> {
+
+    constructor(
+        text: Int,
+        vararg formatArgs: Any
+    ) : this(ApplicationProvider.getApplicationContext<Application>().getString(text, *formatArgs))
+
+    override fun assert(): ErrorDialogPage {
+        assertTextDisplayed(text, root = isDialog())
+        return this
+    }
+
+    fun clickOk() {
+        clickOn(R.string.ok, root = isDialog())
+    }
+}

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/MatchPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/MatchPage.kt
@@ -1,0 +1,21 @@
+package uk.ac.lshtm.keppel.android.support.pages
+
+import uk.ac.lshtm.keppel.android.R
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.Interactions.clickOn
+
+class MatchPage : Page<MatchPage> {
+    override fun assert(): MatchPage {
+        assertTextDisplayed(R.string.match)
+        return this
+    }
+
+    fun clickMatch() {
+        clickOn(R.string.match)
+    }
+
+    fun <T : Page<T>> clickMatch(page: T): T {
+        clickMatch()
+        return page.assert()
+    }
+}

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/Page.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/Page.kt
@@ -1,6 +1,14 @@
 package uk.ac.lshtm.keppel.android.support.pages
 
+import uk.ac.lshtm.keppel.android.support.Assertions
+
 interface Page<T : Page<T>> {
 
     fun assert(): T
+
+    @Suppress("UNCHECKED_CAST")
+    fun assertTextDisplayed(text: String): T {
+        Assertions.assertTextDisplayed(text)
+        return this as T
+    }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/Page.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/Page.kt
@@ -1,0 +1,6 @@
+package uk.ac.lshtm.keppel.android.support.pages
+
+interface Page<T : Page<T>> {
+
+    fun assert(): T
+}

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/SettingsPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/SettingsPage.kt
@@ -1,0 +1,34 @@
+package uk.ac.lshtm.keppel.android.support.pages
+
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import uk.ac.lshtm.keppel.android.R
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextNotDisplayed
+import uk.ac.lshtm.keppel.android.support.Interactions.clickOn
+
+class SettingsPage : Page<SettingsPage> {
+    override fun assert(): SettingsPage {
+        assertTextDisplayed(R.string.app_name)
+        return this
+    }
+
+    fun clickChangeScanner(): ChangeScannerDialogPage {
+        clickOn(R.string.change_scanner)
+        return ChangeScannerDialogPage().assert()
+    }
+}
+
+class ChangeScannerDialogPage : Page<ChangeScannerDialogPage> {
+    override fun assert(): ChangeScannerDialogPage {
+        assertTextDisplayed(R.string.change_scanner, root = isDialog())
+        return this
+    }
+
+    fun changeScanner(newScanner: String) {
+        clickOn(newScanner, root = isDialog())
+    }
+
+    fun assertNoScanner(scanner: String) {
+        assertTextNotDisplayed(scanner, root = isDialog())
+    }
+}

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/matching/SourceAFISMatcher.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/matching/SourceAFISMatcher.kt
@@ -5,9 +5,13 @@ import com.machinezoo.sourceafis.FingerprintMatcher
 import uk.ac.lshtm.keppel.core.Matcher
 
 class SourceAFISMatcher : Matcher {
-    override fun match(one: ByteArray, two: ByteArray): Double {
-        return FingerprintMatcher()
-            .index(convert(one))
-            .match(convert(two))
+    override fun match(one: ByteArray, two: ByteArray): Double? {
+        return try {
+            FingerprintMatcher()
+                .index(convert(one))
+                .match(convert(two))
+        } catch (e: IllegalArgumentException) {
+            null
+        }
     }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -109,7 +109,7 @@ class ScanActivity : AppCompatActivity() {
 
             else -> {
                 MaterialAlertDialogBuilder(this)
-                    .setMessage(R.string.input_hex_error)
+                    .setMessage(R.string.input_format_error)
                     .setPositiveButton(R.string.ok) { _, _ -> finish() }
                     .show()
             }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -33,6 +33,19 @@ class ScanActivity : AppCompatActivity() {
         val binding = ActivityScanBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        if (intent.action == OdkExternal.ACTION_MATCH) {
+            if (intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE) == null) {
+                val error = getString(R.string.input_missing_error, OdkExternal.PARAM_ISO_TEMPLATE)
+
+                MaterialAlertDialogBuilder(this)
+                    .setMessage(error)
+                    .setPositiveButton(R.string.ok) { _, _ -> finish() }
+                    .show()
+
+                return
+            }
+        }
+
         viewModel.scannerState.observe(this) { state ->
             when (state) {
                 ScannerState.Disconnected -> {

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -44,7 +44,12 @@ class ScannerViewModel(
                 val decodedInputTemplate = inputTemplate.fromHex()
                 if (decodedInputTemplate != null) {
                     val score = matcher.match(decodedInputTemplate, capture.isoTemplate.fromHex()!!)
-                    _result.postValue(Result.Match(score, capture))
+
+                    if (score != null) {
+                        _result.postValue(Result.Match(score, capture))
+                    } else {
+                        _result.postValue(Result.Error)
+                    }
                 } else {
                     _result.postValue(Result.Error)
                 }

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="change_scanner">Change scanner</string>
     <string name="app_version">App version</string>
     <string name="match">Match</string>
-    <string name="input_hex_error">Input template is not hex encoded!</string>
+    <string name="input_format_error">Input template is not in the correct format!</string>
     <string name="input_missing_error">\"%1$s\" is missing!</string>
     <string name="ok">Ok</string>
     <string name="cancel">Cancel</string>

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="app_version">App version</string>
     <string name="match">Match</string>
     <string name="input_hex_error">Input template is not hex encoded!</string>
+    <string name="input_missing_error">\"%1$s\" is missing!</string>
     <string name="ok">Ok</string>
     <string name="cancel">Cancel</string>
 </resources>

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/matching/SourceAFISMatcherTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/matching/SourceAFISMatcherTest.kt
@@ -1,0 +1,20 @@
+package uk.ac.lshtm.keppel.android.matching
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class SourceAFISMatcherTest {
+
+    @Test
+    fun `match returns null when one and two are blank`() {
+        val score = SourceAFISMatcher().match("".toByteArray(), "".toByteArray())
+        assertThat(score, equalTo(null))
+    }
+
+    @Test
+    fun `match returns null when one and two are not valid template data`() {
+        val score = SourceAFISMatcher().match("one".toByteArray(), "two".toByteArray())
+        assertThat(score, equalTo(null))
+    }
+}

--- a/Android/core/src/main/java/uk/ac/lshtm/keppel/core/Matcher.kt
+++ b/Android/core/src/main/java/uk/ac/lshtm/keppel/core/Matcher.kt
@@ -2,5 +2,5 @@ package uk.ac.lshtm.keppel.core
 
 interface Matcher {
 
-    fun match(one: ByteArray, two: ByteArray): Double
+    fun match(one: ByteArray, two: ByteArray): Double?
 }


### PR DESCRIPTION
An error will now be shown if a template is not provided to `MATCH`:

<img width="719" alt="Screenshot 2024-04-25 at 11 00 13" src="https://github.com/LSHTM-ORK/ODK_Biometrics/assets/556280/31e7b2e0-793a-4571-b968-5fc8a87b9752">

An error will also be shown if the input template is present, but not hex encoded, blank or invalid:

<img width="719" alt="Screenshot 2024-04-25 at 15 09 33" src="https://github.com/LSHTM-ORK/ODK_Biometrics/assets/556280/fd6a8e62-e29b-4ff1-9c1b-275c7d8ff855">

Additionally, I've made it easier to write new tests by introducing a page objects system.
