### PR TITLE
Add fast mode

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -121,4 +121,5 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
 }

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -121,5 +121,4 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.5.1'
-    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -143,4 +143,29 @@ class MatchActionTest {
             equalTo(fakeScanner.returnTemplate.toHexString())
         )
     }
+
+    @Test
+    fun withFastMode_capturesAndReturnsMatchScore() {
+        val existingTemplate = "blah"
+        fakeMatcher.addScore(
+            existingTemplate,
+            fakeScanner.returnTemplate,
+            96.0
+        )
+
+        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
+            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
+            it.putExtra(OdkExternal.PARAM_FAST, "true")
+        }
+
+        val result = rule.launchAction(intent)
+        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+
+        val extras = result.resultData.extras!!
+        assertThat(
+            extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),
+            equalTo(96.0)
+        )
+    }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -4,13 +4,13 @@ import android.app.Activity
 import android.content.Intent
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import uk.ac.lshtm.keppel.android.support.FakeMatcher
 import uk.ac.lshtm.keppel.android.support.FakeScanner
 import uk.ac.lshtm.keppel.android.support.FakeScannerFactory
 import uk.ac.lshtm.keppel.android.support.KeppelTestRule
+import uk.ac.lshtm.keppel.android.support.pages.CapturingPage
 import uk.ac.lshtm.keppel.android.support.pages.ConnectingPage
 import uk.ac.lshtm.keppel.android.support.pages.ErrorDialogPage
 import uk.ac.lshtm.keppel.android.support.pages.MatchPage
@@ -151,7 +151,6 @@ class MatchActionTest {
     }
 
     @Test
-    @Ignore
     fun withFastMode_capturesAndReturnsMatchScore() {
         val existingTemplate = "blah"
         fakeMatcher.addScore(
@@ -166,7 +165,8 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_FAST, "true")
         }
 
-        val result = rule.launchAction(intent) {
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, CapturingPage())
             fakeScanner.returnTemplate("scanned", 1)
         }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -4,12 +4,14 @@ import android.app.Activity
 import android.content.Intent
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import uk.ac.lshtm.keppel.android.support.FakeMatcher
 import uk.ac.lshtm.keppel.android.support.FakeScanner
 import uk.ac.lshtm.keppel.android.support.FakeScannerFactory
 import uk.ac.lshtm.keppel.android.support.KeppelTestRule
+import uk.ac.lshtm.keppel.android.support.pages.ConnectingPage
 import uk.ac.lshtm.keppel.android.support.pages.ErrorDialogPage
 import uk.ac.lshtm.keppel.android.support.pages.MatchPage
 import uk.ac.lshtm.keppel.core.toHexString
@@ -56,8 +58,8 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
         }
 
-        val result = rule.launchAction(intent, MatchPage()) {
-            it.clickMatch()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, MatchPage()).clickMatch()
             fakeScanner.returnTemplate("scanned", 1)
         }
 
@@ -84,8 +86,8 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate)
         }
 
-        val result = rule.launchAction(intent, MatchPage()) {
-            it.clickMatch()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, MatchPage()).clickMatch()
             fakeScanner.returnTemplate("scanned", 1)
             ErrorDialogPage(R.string.input_format_error).assert().clickOk()
         }
@@ -107,8 +109,8 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
         }
 
-        val result = rule.launchAction(intent, MatchPage()) {
-            it.clickMatch()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, MatchPage()).clickMatch()
             fakeScanner.returnTemplate("scanned", 1)
             ErrorDialogPage(R.string.input_format_error).assert().clickOk()
         }
@@ -132,8 +134,8 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
         }
 
-        val result = rule.launchAction(intent, MatchPage()) {
-            it.clickMatch()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, MatchPage()).clickMatch()
             fakeScanner.returnTemplate("scanned", 17)
         }
 
@@ -149,6 +151,7 @@ class MatchActionTest {
     }
 
     @Test
+    @Ignore
     fun withFastMode_capturesAndReturnsMatchScore() {
         val existingTemplate = "blah"
         fakeMatcher.addScore(

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -29,14 +29,14 @@ class MatchActionTest {
 
     @Test
     fun whenNoTemplateIsSupplied_showsError() {
-        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+        val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
             it.putExtra("blah", "blah")
         }
 
         val result = rule.launchAction(
             intent,
-            ErrorDialogPage(R.string.input_missing_error, OdkExternal.PARAM_ISO_TEMPLATE)
+            ErrorDialogPage(R.string.input_missing_error, External.PARAM_ISO_TEMPLATE)
         ) {
             it.clickOk()
         }
@@ -53,9 +53,9 @@ class MatchActionTest {
             96.0
         )
 
-        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+        val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
-            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
+            it.putExtra(External.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {
@@ -81,9 +81,9 @@ class MatchActionTest {
             96.0
         )
 
-        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+        val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
-            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate)
+            it.putExtra(External.PARAM_ISO_TEMPLATE, existingTemplate)
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {
@@ -104,9 +104,9 @@ class MatchActionTest {
             null
         )
 
-        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+        val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
-            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
+            it.putExtra(External.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {
@@ -127,11 +127,11 @@ class MatchActionTest {
             96.0
         )
 
-        val intent = Intent(OdkExternal.ACTION_MATCH).also {
-            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
-            it.putExtra(OdkExternal.PARAM_RETURN_SCORE, "my_score")
-            it.putExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
-            it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
+        val intent = Intent(External.ACTION_MATCH).also {
+            it.putExtra(External.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
+            it.putExtra(External.PARAM_RETURN_SCORE, "my_score")
+            it.putExtra(External.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
+            it.putExtra(External.PARAM_RETURN_NFIQ, "my_nfiq")
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {
@@ -159,10 +159,10 @@ class MatchActionTest {
             96.0
         )
 
-        val intent = Intent(OdkExternal.ACTION_MATCH).also {
+        val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
-            it.putExtra(OdkExternal.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
-            it.putExtra(OdkExternal.PARAM_FAST, "true")
+            it.putExtra(External.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
+            it.putExtra(External.PARAM_FAST, "true")
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -47,7 +47,7 @@ class MatchActionTest {
         val existingTemplate = "blah"
         fakeMatcher.addScore(
             existingTemplate,
-            fakeScanner.returnTemplate,
+            "scanned",
             96.0
         )
 
@@ -58,6 +58,7 @@ class MatchActionTest {
 
         val result = rule.launchAction(intent, MatchPage()) {
             it.clickMatch()
+            fakeScanner.returnTemplate("scanned", 1)
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
@@ -74,7 +75,7 @@ class MatchActionTest {
         val existingTemplate = "blah"
         fakeMatcher.addScore(
             existingTemplate,
-            fakeScanner.returnTemplate,
+            "scanned",
             96.0
         )
 
@@ -84,8 +85,9 @@ class MatchActionTest {
         }
 
         val result = rule.launchAction(intent, MatchPage()) {
-            it.clickMatch(ErrorDialogPage(R.string.input_format_error))
-                .clickOk()
+            it.clickMatch()
+            fakeScanner.returnTemplate("scanned", 1)
+            ErrorDialogPage(R.string.input_format_error).assert().clickOk()
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
@@ -96,7 +98,7 @@ class MatchActionTest {
         val existingTemplate = "blah"
         fakeMatcher.addScore(
             existingTemplate,
-            fakeScanner.returnTemplate,
+            "scanned",
             null
         )
 
@@ -106,8 +108,9 @@ class MatchActionTest {
         }
 
         val result = rule.launchAction(intent, MatchPage()) {
-            it.clickMatch(ErrorDialogPage(R.string.input_format_error))
-                .clickOk()
+            it.clickMatch()
+            fakeScanner.returnTemplate("scanned", 1)
+            ErrorDialogPage(R.string.input_format_error).assert().clickOk()
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
@@ -118,7 +121,7 @@ class MatchActionTest {
         val existingTemplate = "blah"
         fakeMatcher.addScore(
             existingTemplate,
-            fakeScanner.returnTemplate,
+            "scanned",
             96.0
         )
 
@@ -131,6 +134,7 @@ class MatchActionTest {
 
         val result = rule.launchAction(intent, MatchPage()) {
             it.clickMatch()
+            fakeScanner.returnTemplate("scanned", 17)
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
@@ -140,7 +144,7 @@ class MatchActionTest {
         assertThat(extras.getInt("my_nfiq"), equalTo(17))
         assertThat(
             extras.getString("my_iso_template"),
-            equalTo(fakeScanner.returnTemplate.toHexString())
+            equalTo("scanned".toHexString())
         )
     }
 
@@ -149,7 +153,7 @@ class MatchActionTest {
         val existingTemplate = "blah"
         fakeMatcher.addScore(
             existingTemplate,
-            fakeScanner.returnTemplate,
+            "scanned",
             96.0
         )
 
@@ -159,9 +163,11 @@ class MatchActionTest {
             it.putExtra(OdkExternal.PARAM_FAST, "true")
         }
 
-        val result = rule.launchAction(intent)
-        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+        val result = rule.launchAction(intent) {
+            fakeScanner.returnTemplate("scanned", 1)
+        }
 
+        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
         val extras = result.resultData.extras!!
         assertThat(
             extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -26,7 +26,7 @@ class ScanActionTest {
 
     @Test
     fun clickingCapture_capturesAndReturnsIsoTemplate() {
-        val intent = Intent(OdkExternal.ACTION_SCAN).also {
+        val intent = Intent(External.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
         }
 
@@ -45,9 +45,9 @@ class ScanActionTest {
 
     @Test
     fun clickingCapture_whenReturnValuesSpecified_capturesAndReturnsThoseValues() {
-        val intent = Intent(OdkExternal.ACTION_SCAN).also {
-            it.putExtra(OdkExternal.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
-            it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
+        val intent = Intent(External.ACTION_SCAN).also {
+            it.putExtra(External.PARAM_RETURN_ISO_TEMPLATE, "my_iso_template")
+            it.putExtra(External.PARAM_RETURN_NFIQ, "my_nfiq")
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {
@@ -63,7 +63,7 @@ class ScanActionTest {
 
     @Test
     fun clickingCapture_andThenCancel_returnsCancelledResult() {
-        val intent = Intent(OdkExternal.ACTION_SCAN).also {
+        val intent = Intent(External.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
         }
 
@@ -79,9 +79,9 @@ class ScanActionTest {
 
     @Test
     fun withFastMode_capturesAndReturnsIsoTemplate() {
-        val intent = Intent(OdkExternal.ACTION_SCAN).also {
+        val intent = Intent(External.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
-            it.putExtra(OdkExternal.PARAM_FAST, "true")
+            it.putExtra(External.PARAM_FAST, "true")
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -77,4 +77,21 @@ class ScanActionTest {
         assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
         assertThat(result.resultData, equalTo(null))
     }
+
+    @Test
+    fun withFastMode_capturesAndReturnsIsoTemplate() {
+        val intent = Intent(OdkExternal.ACTION_SCAN).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
+            it.putExtra(OdkExternal.PARAM_FAST, "true")
+        }
+
+        val result = rule.launchAction(intent)
+
+        assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+        val extras = result.resultData.extras!!
+        assertThat(
+            extras.getString(OdkExternal.PARAM_RETURN_VALUE),
+            equalTo("ISO TEMPLATE".toHexString())
+        )
+    }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +12,7 @@ import uk.ac.lshtm.keppel.android.support.FakeScanner
 import uk.ac.lshtm.keppel.android.support.FakeScannerFactory
 import uk.ac.lshtm.keppel.android.support.KeppelTestRule
 import uk.ac.lshtm.keppel.android.support.pages.CapturePage
+import uk.ac.lshtm.keppel.android.support.pages.CapturingPage
 import uk.ac.lshtm.keppel.android.support.pages.ConnectingPage
 import uk.ac.lshtm.keppel.core.toHexString
 
@@ -78,15 +78,14 @@ class ScanActionTest {
     }
 
     @Test
-    @Ignore
     fun withFastMode_capturesAndReturnsIsoTemplate() {
         val intent = Intent(OdkExternal.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
             it.putExtra(OdkExternal.PARAM_FAST, "true")
         }
 
-        val result = rule.launchAction(intent) {
-            fakeScanner.connect()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, CapturingPage())
             fakeScanner.returnTemplate("scanned", 1)
         }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -30,13 +30,14 @@ class ScanActionTest {
 
         val result = rule.launchAction(intent, CapturePage()) {
             it.clickCapture()
+            fakeScanner.returnTemplate("scanned", 1)
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
         val extras = result.resultData.extras!!
         assertThat(
             extras.getString(OdkExternal.PARAM_RETURN_VALUE),
-            equalTo("ISO TEMPLATE".toHexString())
+            equalTo("scanned".toHexString())
         )
     }
 
@@ -49,14 +50,12 @@ class ScanActionTest {
 
         val result = rule.launchAction(intent, CapturePage()) {
             it.clickCapture()
+            fakeScanner.returnTemplate("scanned", 17)
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
         val extras = result.resultData.extras!!
-        assertThat(
-            extras.get("my_iso_template"),
-            equalTo("ISO TEMPLATE".toHexString())
-        )
+        assertThat(extras.get("my_iso_template"), equalTo("scanned".toHexString()))
         assertThat(extras.get("my_nfiq"), equalTo(17))
     }
 
@@ -67,9 +66,6 @@ class ScanActionTest {
         }
 
         val result = rule.launchAction(intent, CapturePage()) {
-            fakeScanner.neverCapture = true // Make sure we have a chance to hit "Cancel"
-            rule.waitForBackgroundTasks = false // Allow task to run while interacting with UI
-
             it.clickCapture()
             it.clickCancel()
         }
@@ -85,13 +81,15 @@ class ScanActionTest {
             it.putExtra(OdkExternal.PARAM_FAST, "true")
         }
 
-        val result = rule.launchAction(intent)
+        val result = rule.launchAction(intent) {
+            fakeScanner.returnTemplate("scanned", 1)
+        }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
         val extras = result.resultData.extras!!
         assertThat(
             extras.getString(OdkExternal.PARAM_RETURN_VALUE),
-            equalTo("ISO TEMPLATE".toHexString())
+            equalTo("scanned".toHexString())
         )
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,6 +13,7 @@ import uk.ac.lshtm.keppel.android.support.FakeScanner
 import uk.ac.lshtm.keppel.android.support.FakeScannerFactory
 import uk.ac.lshtm.keppel.android.support.KeppelTestRule
 import uk.ac.lshtm.keppel.android.support.pages.CapturePage
+import uk.ac.lshtm.keppel.android.support.pages.ConnectingPage
 import uk.ac.lshtm.keppel.core.toHexString
 
 @RunWith(AndroidJUnit4::class)
@@ -28,8 +30,8 @@ class ScanActionTest {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
         }
 
-        val result = rule.launchAction(intent, CapturePage()) {
-            it.clickCapture()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, CapturePage()).clickCapture()
             fakeScanner.returnTemplate("scanned", 1)
         }
 
@@ -48,8 +50,8 @@ class ScanActionTest {
             it.putExtra(OdkExternal.PARAM_RETURN_NFIQ, "my_nfiq")
         }
 
-        val result = rule.launchAction(intent, CapturePage()) {
-            it.clickCapture()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, CapturePage()).clickCapture()
             fakeScanner.returnTemplate("scanned", 17)
         }
 
@@ -65,9 +67,10 @@ class ScanActionTest {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
         }
 
-        val result = rule.launchAction(intent, CapturePage()) {
-            it.clickCapture()
-            it.clickCancel()
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, CapturePage())
+                .clickCapture()
+                .clickCancel()
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
@@ -75,6 +78,7 @@ class ScanActionTest {
     }
 
     @Test
+    @Ignore
     fun withFastMode_capturesAndReturnsIsoTemplate() {
         val intent = Intent(OdkExternal.ACTION_SCAN).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
@@ -82,6 +86,7 @@ class ScanActionTest {
         }
 
         val result = rule.launchAction(intent) {
+            fakeScanner.connect()
             fakeScanner.returnTemplate("scanned", 1)
         }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Assertions.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/Assertions.kt
@@ -8,8 +8,8 @@ import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matcher
+import org.hamcrest.Matchers.allOf
 
 object Assertions {
 
@@ -27,11 +27,17 @@ object Assertions {
         assertTextDisplayed(string, root)
     }
 
+    fun assertTextNotDisplayed(text: Int, vararg formatArgs: Any, root: Matcher<Root>? = null) {
+        val string =
+            ApplicationProvider.getApplicationContext<Application>().getString(text, *formatArgs)
+        assertTextNotDisplayed(string, root)
+    }
+
     fun assertTextNotDisplayed(text: String, root: Matcher<Root>? = null) {
         if (root != null) {
-            onView(withText(text)).inRoot(root).check(doesNotExist())
+            onView(allOf(withText(text), isDisplayed())).inRoot(root).check(doesNotExist())
         } else {
-            onView(withText(text)).check(doesNotExist())
+            onView(allOf(withText(text), isDisplayed())).check(doesNotExist())
         }
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
@@ -66,15 +66,6 @@ class KeppelTestRule(
         return scenario.result
     }
 
-    fun launchAction(
-        intent: Intent,
-        block: () -> Unit
-    ): Instrumentation.ActivityResult {
-        val scenario = launchActivityScenario(intent)
-        block()
-        return scenario.result
-    }
-
     private fun launchActivityScenario(intent: Intent): ActivityScenario<Activity> {
         return ActivityScenario.launchActivityForResult<Activity>(intent).also {
             activityScenario = it

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/KeppelTestRule.kt
@@ -67,12 +67,19 @@ class KeppelTestRule(
         page: T,
         block: (T) -> Unit
     ): Instrumentation.ActivityResult {
-        val scenario = launchAction(intent)
+        val scenario = launchActivityScenario(intent)
         block(page.assert())
         return scenario.result
     }
 
-    private fun launchAction(intent: Intent): ActivityScenario<Activity> {
+    fun <T : Page<T>> launchAction(
+        intent: Intent
+    ): Instrumentation.ActivityResult {
+        val scenario = launchActivityScenario(intent)
+        return scenario.result
+    }
+
+    private fun launchActivityScenario(intent: Intent): ActivityScenario<Activity> {
         return ActivityScenario.launchActivityForResult<Activity>(intent).also {
             activityScenario = it
         }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturePage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturePage.kt
@@ -2,11 +2,14 @@ package uk.ac.lshtm.keppel.android.support.pages
 
 import uk.ac.lshtm.keppel.android.R
 import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextNotDisplayed
 import uk.ac.lshtm.keppel.android.support.Interactions.clickOn
 
 class CapturePage : Page<CapturePage> {
     override fun assert(): CapturePage {
         assertTextDisplayed(R.string.capture)
+        assertTextNotDisplayed(R.string.connect_scanner)
+        assertTextNotDisplayed(R.string.place_finger)
         return this
     }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturingPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturingPage.kt
@@ -4,14 +4,13 @@ import uk.ac.lshtm.keppel.android.R
 import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
 import uk.ac.lshtm.keppel.android.support.Interactions.clickOn
 
-class CapturePage : Page<CapturePage> {
-    override fun assert(): CapturePage {
-        assertTextDisplayed(R.string.capture)
+class CapturingPage : Page<CapturingPage> {
+    override fun assert(): CapturingPage {
+        assertTextDisplayed(R.string.place_finger)
         return this
     }
 
-    fun clickCapture(): CapturingPage {
-        clickOn(R.string.capture)
-        return CapturingPage().assert()
+    fun clickCancel() {
+        clickOn(R.string.cancel)
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturingPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/CapturingPage.kt
@@ -2,11 +2,14 @@ package uk.ac.lshtm.keppel.android.support.pages
 
 import uk.ac.lshtm.keppel.android.R
 import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextNotDisplayed
 import uk.ac.lshtm.keppel.android.support.Interactions.clickOn
 
 class CapturingPage : Page<CapturingPage> {
     override fun assert(): CapturingPage {
         assertTextDisplayed(R.string.place_finger)
+        assertTextNotDisplayed(R.string.capture)
+        assertTextNotDisplayed(R.string.match)
         return this
     }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/ConnectingPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/ConnectingPage.kt
@@ -1,0 +1,17 @@
+package uk.ac.lshtm.keppel.android.support.pages
+
+import uk.ac.lshtm.keppel.android.R
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.FakeScanner
+
+class ConnectingPage : Page<ConnectingPage> {
+    override fun assert(): ConnectingPage {
+        assertTextDisplayed(R.string.connect_scanner)
+        return this
+    }
+
+    fun <T : Page<T>> connect(fakeScanner: FakeScanner, destination: T): T {
+        fakeScanner.connect()
+        return destination.assert()
+    }
+}

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/ConnectingPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/ConnectingPage.kt
@@ -2,11 +2,14 @@ package uk.ac.lshtm.keppel.android.support.pages
 
 import uk.ac.lshtm.keppel.android.R
 import uk.ac.lshtm.keppel.android.support.Assertions.assertTextDisplayed
+import uk.ac.lshtm.keppel.android.support.Assertions.assertTextNotDisplayed
 import uk.ac.lshtm.keppel.android.support.FakeScanner
 
 class ConnectingPage : Page<ConnectingPage> {
     override fun assert(): ConnectingPage {
         assertTextDisplayed(R.string.connect_scanner)
+        assertTextNotDisplayed(R.string.capture)
+        assertTextNotDisplayed(R.string.place_finger)
         return this
     }
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/MatchPage.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/pages/MatchPage.kt
@@ -13,9 +13,4 @@ class MatchPage : Page<MatchPage> {
     fun clickMatch() {
         clickOn(R.string.match)
     }
-
-    fun <T : Page<T>> clickMatch(page: T): T {
-        clickMatch()
-        return page.assert()
-    }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/External.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/External.kt
@@ -1,0 +1,15 @@
+package uk.ac.lshtm.keppel.android
+
+object External {
+    private const val APP_ID = "uk.ac.lshtm.keppel.android"
+
+    const val ACTION_SCAN = "$APP_ID.SCAN"
+    const val ACTION_MATCH = "$APP_ID.MATCH"
+
+    const val PARAM_RETURN_ISO_TEMPLATE = "$APP_ID.return_iso_template"
+    const val PARAM_RETURN_NFIQ = "$APP_ID.return_nfiq"
+    const val PARAM_RETURN_SCORE = "$APP_ID.return_score"
+    const val PARAM_ISO_TEMPLATE = "$APP_ID.iso_template"
+
+    const val PARAM_FAST = "$APP_ID.fast"
+}

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/Keppel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/Keppel.kt
@@ -2,7 +2,6 @@ package uk.ac.lshtm.keppel.android
 
 import android.app.Activity
 import android.app.Application
-import android.os.Build
 import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import androidx.preference.PreferenceManager.getDefaultSharedPreferences
@@ -15,7 +14,6 @@ import uk.ac.lshtm.keppel.android.tasks.IODispatcherTaskRunner
 import uk.ac.lshtm.keppel.core.Analytics
 import uk.ac.lshtm.keppel.core.Matcher
 import uk.ac.lshtm.keppel.core.TaskRunner
-import javax.xml.transform.Source
 
 class Keppel : Application() {
 

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
@@ -18,8 +18,8 @@ object OdkExternal {
 
     const val PARAM_FAST = "$APP_ID.fast"
 
-    fun isSingleReturn(intent: Intent): Boolean {
-        return intent.extras?.containsKey(PARAM_INPUT_VALUE) == true
+    fun isSingleReturn(odkExternalRequest: OdkExternalRequest): Boolean {
+        return odkExternalRequest.inputValue != null
     }
 
     fun buildSingleReturnIntent(double: Double): Intent {
@@ -34,11 +34,14 @@ object OdkExternal {
         }
     }
 
-    fun buildMultipleReturnResult(inputIntent: Intent, results: Map<String, Any>): Intent {
+    fun buildMultipleReturnResult(
+        params:  Map<String, String>,
+        results: Map<String, Any>
+    ): Intent {
         return Intent().also {
             results.forEach { (key, value) ->
-                if (inputIntent.hasExtra(key)) {
-                    val returnExtra = inputIntent.getStringExtra(key)
+                if (params.containsKey(key)) {
+                    val returnExtra = params.get(key)
 
                     when (value) {
                         is Double -> it.putExtra(returnExtra, value)
@@ -49,4 +52,20 @@ object OdkExternal {
             }
         }
     }
+
+    fun parseIntent(intent: Intent): OdkExternalRequest {
+        val params = intent.extras?.keySet()?.associate { Pair(it, intent.getStringExtra(it)!!) }
+
+        return OdkExternalRequest(
+            intent.action!!,
+            intent.getStringExtra(PARAM_INPUT_VALUE),
+            params ?: emptyMap()
+        )
+    }
 }
+
+data class OdkExternalRequest(
+    val action: String,
+    val inputValue: String?,
+    val params: Map<String, String>
+)

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
@@ -3,20 +3,9 @@ package uk.ac.lshtm.keppel.android
 import android.content.Intent
 
 object OdkExternal {
+
     const val PARAM_INPUT_VALUE = "value"
     const val PARAM_RETURN_VALUE = "value"
-
-    private const val APP_ID = "uk.ac.lshtm.keppel.android"
-
-    const val ACTION_SCAN = "$APP_ID.SCAN"
-    const val ACTION_MATCH = "$APP_ID.MATCH"
-
-    const val PARAM_RETURN_ISO_TEMPLATE = "$APP_ID.return_iso_template"
-    const val PARAM_RETURN_NFIQ = "$APP_ID.return_nfiq"
-    const val PARAM_RETURN_SCORE = "$APP_ID.return_score"
-    const val PARAM_ISO_TEMPLATE = "$APP_ID.iso_template"
-
-    const val PARAM_FAST = "$APP_ID.fast"
 
     fun isSingleReturn(odkExternalRequest: OdkExternalRequest): Boolean {
         return odkExternalRequest.inputValue != null

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
@@ -16,6 +16,8 @@ object OdkExternal {
     const val PARAM_RETURN_SCORE = "$APP_ID.return_score"
     const val PARAM_ISO_TEMPLATE = "$APP_ID.iso_template"
 
+    const val PARAM_FAST = "$APP_ID.fast"
+
     fun isSingleReturn(intent: Intent): Boolean {
         return intent.extras?.containsKey(PARAM_INPUT_VALUE) == true
     }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -1,0 +1,28 @@
+package uk.ac.lshtm.keppel.android.scanning
+
+import android.content.Intent
+import uk.ac.lshtm.keppel.android.OdkExternal
+
+object IntentParser {
+    fun parse(intent: Intent): Request {
+        val fast = intent.extras?.getString(OdkExternal.PARAM_FAST) == "true"
+
+        return if (intent.action == OdkExternal.ACTION_MATCH) {
+            Request.Match(
+                intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE),
+                fast
+            )
+        } else {
+            Request.Scan(
+                fast
+            )
+        }
+    }
+}
+
+sealed interface Request {
+    val fast: Boolean
+
+    data class Scan(override val fast: Boolean) : Request
+    data class Match(val isoTemplate: String?, override val fast: Boolean) : Request
+}

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -2,27 +2,40 @@ package uk.ac.lshtm.keppel.android.scanning
 
 import android.content.Intent
 import uk.ac.lshtm.keppel.android.OdkExternal
+import uk.ac.lshtm.keppel.android.OdkExternalRequest
 
 object IntentParser {
     fun parse(intent: Intent): Request {
-        val fast = intent.extras?.getString(OdkExternal.PARAM_FAST) == "true"
+        val odkExternalRequest = OdkExternal.parseIntent(intent)
+        val fast = odkExternalRequest.params[OdkExternal.PARAM_FAST] == "true"
 
-        return if (intent.action == OdkExternal.ACTION_MATCH) {
+        return if (odkExternalRequest.action == OdkExternal.ACTION_MATCH) {
             Request.Match(
                 intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE),
-                fast
+                fast,
+                odkExternalRequest
             )
         } else {
             Request.Scan(
-                fast
+                fast,
+                odkExternalRequest
             )
         }
     }
 }
 
 sealed interface Request {
-    val fast: Boolean
 
-    data class Scan(override val fast: Boolean) : Request
-    data class Match(val isoTemplate: String?, override val fast: Boolean) : Request
+    val fast: Boolean
+    val odkExternalRequest: OdkExternalRequest
+
+    data class Scan(
+        override val fast: Boolean,
+        override val odkExternalRequest: OdkExternalRequest
+    ) : Request
+
+    data class Match(
+        val isoTemplate: String?, override val fast: Boolean,
+        override val odkExternalRequest: OdkExternalRequest
+    ) : Request
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -1,17 +1,18 @@
 package uk.ac.lshtm.keppel.android.scanning
 
 import android.content.Intent
+import uk.ac.lshtm.keppel.android.External
 import uk.ac.lshtm.keppel.android.OdkExternal
 import uk.ac.lshtm.keppel.android.OdkExternalRequest
 
 object IntentParser {
     fun parse(intent: Intent): Request {
         val odkExternalRequest = OdkExternal.parseIntent(intent)
-        val fast = odkExternalRequest.params[OdkExternal.PARAM_FAST] == "true"
+        val fast = odkExternalRequest.params[External.PARAM_FAST] == "true"
 
-        return if (odkExternalRequest.action == OdkExternal.ACTION_MATCH) {
+        return if (odkExternalRequest.action == External.ACTION_MATCH) {
             Request.Match(
-                intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE),
+                intent.extras!!.getString(External.PARAM_ISO_TEMPLATE),
                 fast,
                 odkExternalRequest
             )

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -55,9 +55,13 @@ class ScanActivity : AppCompatActivity() {
                 }
 
                 ScannerState.Connected -> {
-                    binding.connectProgressBar.visibility = View.GONE
-                    binding.captureButton.visibility = View.VISIBLE
-                    binding.captureProgressBar.visibility = View.GONE
+                    if (intent.extras?.containsKey(OdkExternal.PARAM_FAST) == true) {
+                        capture()
+                    } else {
+                        binding.connectProgressBar.visibility = View.GONE
+                        binding.captureButton.visibility = View.VISIBLE
+                        binding.captureProgressBar.visibility = View.GONE
+                    }
                 }
 
                 ScannerState.Scanning -> {
@@ -84,10 +88,6 @@ class ScanActivity : AppCompatActivity() {
 
         if (intent.action == OdkExternal.ACTION_MATCH) {
             binding.captureButton.setText(R.string.match)
-        }
-
-        if (intent.extras?.containsKey(OdkExternal.PARAM_FAST) == true) {
-            capture()
         }
     }
 

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -75,12 +75,7 @@ class ScanActivity : AppCompatActivity() {
         }
 
         binding.captureButton.setOnClickListener {
-            if (intent.action == OdkExternal.ACTION_MATCH) {
-                val inputTemplate = intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE)
-                viewModel.capture(inputTemplate)
-            } else {
-                viewModel.capture()
-            }
+            capture()
         }
 
         binding.cancelButton.setOnClickListener {
@@ -89,6 +84,19 @@ class ScanActivity : AppCompatActivity() {
 
         if (intent.action == OdkExternal.ACTION_MATCH) {
             binding.captureButton.setText(R.string.match)
+        }
+
+        if (intent.extras?.containsKey(OdkExternal.PARAM_FAST) == true) {
+            capture()
+        }
+    }
+
+    private fun capture() {
+        if (intent.action == OdkExternal.ACTION_MATCH) {
+            val inputTemplate = intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE)
+            viewModel.capture(inputTemplate)
+        } else {
+            viewModel.capture()
         }
     }
 

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -162,25 +162,3 @@ class ScanActivity : AppCompatActivity() {
         }
     }
 }
-
-private object IntentParser {
-    fun parse(intent: Intent): Request {
-        return if (intent.action == OdkExternal.ACTION_MATCH) {
-            Request.Match(
-                intent.extras!!.getString(OdkExternal.PARAM_ISO_TEMPLATE),
-                intent.extras?.containsKey(OdkExternal.PARAM_FAST) == true
-            )
-        } else {
-            Request.Scan(
-                intent.extras?.containsKey(OdkExternal.PARAM_FAST) == true
-            )
-        }
-    }
-}
-
-private sealed interface Request {
-    val fast: Boolean
-
-    data class Scan(override val fast: Boolean) : Request
-    data class Match(val isoTemplate: String?, override val fast: Boolean) : Request
-}

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import uk.ac.lshtm.keppel.android.External
 import uk.ac.lshtm.keppel.android.OdkExternal
 import uk.ac.lshtm.keppel.android.OdkExternalRequest
 import uk.ac.lshtm.keppel.android.R
@@ -38,7 +39,7 @@ class ScanActivity : AppCompatActivity() {
 
         if (request is Request.Match) {
             if (request.isoTemplate == null) {
-                val error = getString(R.string.input_missing_error, OdkExternal.PARAM_ISO_TEMPLATE)
+                val error = getString(R.string.input_missing_error, External.PARAM_ISO_TEMPLATE)
 
                 MaterialAlertDialogBuilder(this)
                     .setMessage(error)
@@ -147,8 +148,8 @@ class ScanActivity : AppCompatActivity() {
         } else {
             OdkExternal.buildMultipleReturnResult(
                 odkExternalRequest.params, mapOf(
-                    OdkExternal.PARAM_RETURN_ISO_TEMPLATE to capture.isoTemplate,
-                    OdkExternal.PARAM_RETURN_NFIQ to capture.nfiq
+                    External.PARAM_RETURN_ISO_TEMPLATE to capture.isoTemplate,
+                    External.PARAM_RETURN_NFIQ to capture.nfiq
                 )
             )
         }
@@ -164,9 +165,9 @@ class ScanActivity : AppCompatActivity() {
         } else {
             OdkExternal.buildMultipleReturnResult(
                 odkExternalRequest.params, mapOf(
-                    OdkExternal.PARAM_RETURN_SCORE to score,
-                    OdkExternal.PARAM_RETURN_ISO_TEMPLATE to capture.isoTemplate,
-                    OdkExternal.PARAM_RETURN_NFIQ to capture.nfiq
+                    External.PARAM_RETURN_SCORE to score,
+                    External.PARAM_RETURN_ISO_TEMPLATE to capture.isoTemplate,
+                    External.PARAM_RETURN_NFIQ to capture.nfiq
                 )
             )
         }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -3,7 +3,6 @@ package uk.ac.lshtm.keppel.android.scanning
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState.Connected
 import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState.Disconnected
 import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState.Scanning

--- a/Android/app/src/main/res/xml/preferences.xml
+++ b/Android/app/src/main/res/xml/preferences.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ListPreference
         app:dialogTitle="@string/change_scanner"

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/OdkExternalTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/OdkExternalTest.kt
@@ -1,6 +1,5 @@
 package uk.ac.lshtm.keppel.android
 
-import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -12,38 +11,27 @@ class OdkExternalTest {
 
     @Test
     fun `buildMultipleReturnResult does not include result when key is not in input intent`() {
-        val inputIntent = Intent().also {
-            it.putExtra("my_return_param", "my_return_field")
-        }
+        val params = mapOf("my_return_param" to "my_return_field")
         val results =
             mapOf("my_return_param" to "result", "my_other_return_param" to "other result")
-        val intent =
-            OdkExternal.buildMultipleReturnResult(inputIntent, results)
+        val intent = OdkExternal.buildMultipleReturnResult(params, results)
         assertThat(intent.extras!!.size(), equalTo(1))
         assertThat(intent.extras!!.getString("my_return_field"), equalTo("result"))
     }
 
     @Test
     fun `buildMultipleReturnResult can include double results`() {
-        val inputIntent = Intent().also {
-            it.putExtra("my_return_param", "my_return_field")
-        }
-        val results =
-            mapOf("my_return_param" to 12.0)
-        val intent =
-            OdkExternal.buildMultipleReturnResult(inputIntent, results)
+        val params = mapOf("my_return_param" to "my_return_field")
+        val results = mapOf("my_return_param" to 12.0)
+        val intent = OdkExternal.buildMultipleReturnResult(params, results)
         assertThat(intent.extras!!.getDouble("my_return_field"), equalTo(12.0))
     }
 
     @Test
     fun `buildMultipleReturnResult can include int results`() {
-        val inputIntent = Intent().also {
-            it.putExtra("my_return_param", "my_return_field")
-        }
-        val results =
-            mapOf("my_return_param" to 12)
-        val intent =
-            OdkExternal.buildMultipleReturnResult(inputIntent, results)
+        val params = mapOf("my_return_param" to "my_return_field")
+        val results = mapOf("my_return_param" to 12)
+        val intent = OdkExternal.buildMultipleReturnResult(params, results)
         assertThat(intent.extras!!.getInt("my_return_field"), equalTo(12))
     }
 }

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
@@ -1,0 +1,33 @@
+package uk.ac.lshtm.keppel.android.scanning
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import uk.ac.lshtm.keppel.android.OdkExternal
+
+@RunWith(AndroidJUnit4::class)
+class IntentParserTest {
+
+    @Test
+    fun `fast is false when param is false string`() {
+        val intent = Intent().also {
+            it.putExtra(OdkExternal.PARAM_FAST, "false")
+        }
+
+        val request = IntentParser.parse(intent)
+        assertThat(request.fast, equalTo(false))
+    }
+
+    @Test
+    fun `fast is false when param is arbitrary string`() {
+        val intent = Intent().also {
+            it.putExtra(OdkExternal.PARAM_FAST, "blah")
+        }
+
+        val request = IntentParser.parse(intent)
+        assertThat(request.fast, equalTo(false))
+    }
+}

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
@@ -6,7 +6,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
-import uk.ac.lshtm.keppel.android.OdkExternal
+import uk.ac.lshtm.keppel.android.External
 
 @RunWith(AndroidJUnit4::class)
 class IntentParserTest {
@@ -14,8 +14,8 @@ class IntentParserTest {
     @Test
     fun `fast is false when param is false string`() {
         val intent = Intent().also {
-            it.action = OdkExternal.ACTION_SCAN
-            it.putExtra(OdkExternal.PARAM_FAST, "false")
+            it.action = External.ACTION_SCAN
+            it.putExtra(External.PARAM_FAST, "false")
         }
 
         val request = IntentParser.parse(intent)
@@ -25,8 +25,8 @@ class IntentParserTest {
     @Test
     fun `fast is false when param is arbitrary string`() {
         val intent = Intent().also {
-            it.action = OdkExternal.ACTION_SCAN
-            it.putExtra(OdkExternal.PARAM_FAST, "blah")
+            it.action = External.ACTION_SCAN
+            it.putExtra(External.PARAM_FAST, "blah")
         }
 
         val request = IntentParser.parse(intent)

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
@@ -14,6 +14,7 @@ class IntentParserTest {
     @Test
     fun `fast is false when param is false string`() {
         val intent = Intent().also {
+            it.action = OdkExternal.ACTION_SCAN
             it.putExtra(OdkExternal.PARAM_FAST, "false")
         }
 
@@ -24,6 +25,7 @@ class IntentParserTest {
     @Test
     fun `fast is false when param is arbitrary string`() {
         val intent = Intent().also {
+            it.action = OdkExternal.ACTION_SCAN
             it.putExtra(OdkExternal.PARAM_FAST, "blah")
         }
 

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScanActivityTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScanActivityTest.kt
@@ -1,29 +1,24 @@
 package uk.ac.lshtm.keppel.android.scanning
 
 import android.content.Context
-import android.view.View
 import androidx.test.core.app.ApplicationProvider
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.spy
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.annotation.LooperMode
 import uk.ac.lshtm.keppel.android.Keppel
-import uk.ac.lshtm.keppel.android.R
-import uk.ac.lshtm.keppel.core.CaptureResult
 import uk.ac.lshtm.keppel.core.Scanner
 
 @RunWith(RobolectricTestRunner::class)
 @LooperMode(LooperMode.Mode.PAUSED)
 class ScanActivityTest {
 
-    private val fakeScanner = spy(FakeScanner())
+    private val fakeScanner = mock<Scanner>()
     private lateinit var activity: ScanActivity
     private lateinit var activityController: ActivityController<ScanActivity>
 
@@ -38,74 +33,16 @@ class ScanActivityTest {
     }
 
     @Test
-    fun whenScannerDisconnected_showsConnectProgressBar() {
-        assertThat(activity.findViewById<View>(R.id.capture_button).visibility, equalTo(View.GONE))
-        assertThat(activity.findViewById<View>(R.id.capture_progress_bar).visibility, equalTo(View.GONE))
-        assertThat(activity.findViewById<View>(R.id.connect_progress_bar).visibility, equalTo(View.VISIBLE))
-    }
-
-    @Test
-    fun whenScannerConnected_clickingCapture_showsProgressBar() {
-        fakeScanner.connect()
-
-        activity.findViewById<View>(R.id.capture_button).performClick()
-        assertThat(activity.findViewById<View>(R.id.capture_button).visibility, equalTo(View.GONE))
-        assertThat(activity.findViewById<View>(R.id.capture_progress_bar).visibility, equalTo(View.VISIBLE))
-        assertThat(activity.findViewById<View>(R.id.connect_progress_bar).visibility, equalTo(View.GONE))
-    }
-
-    @Test
-    fun whenScannerConnected_thenDisconnected_showsConnectProgressBar() {
-        fakeScanner.connect()
-        fakeScanner.disconnect()
-
-        assertThat(activity.findViewById<View>(R.id.capture_button).visibility, equalTo(View.GONE))
-        assertThat(activity.findViewById<View>(R.id.capture_progress_bar).visibility, equalTo(View.GONE))
-        assertThat(activity.findViewById<View>(R.id.connect_progress_bar).visibility, equalTo(View.VISIBLE))
-    }
-
-    @Test
     fun pausing_stopsCapture() {
         activityController.pause()
         verify(fakeScanner).stopCapture()
     }
 }
 
-class FakeScannerFactory(private val fakeScanner: FakeScanner) : ScannerFactory {
+class FakeScannerFactory(private val scanner: Scanner) : ScannerFactory {
 
     override val name: String = "Fake"
     override val isAvailable: Boolean = true
 
-    override fun create(context: Context): Scanner = fakeScanner
-}
-
-open class FakeScanner : Scanner {
-
-    private var onDisconnected: (() -> Unit)? = null
-    private lateinit var onConnected: () -> Unit
-
-    fun connect() {
-        onConnected()
-    }
-
-    override fun connect(onConnected: () -> Unit): Scanner {
-        this.onConnected = onConnected
-        return this
-    }
-
-    override fun onDisconnect(onDisconnected: () -> Unit) {
-        this.onDisconnected = onDisconnected
-    }
-
-    override fun capture(): CaptureResult? {
-        return CaptureResult("", 0)
-    }
-
-    override fun stopCapture() {
-
-    }
-
-    override fun disconnect() {
-        onDisconnected?.invoke()
-    }
+    override fun create(context: Context): Scanner = scanner
 }

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScanActivityTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScanActivityTest.kt
@@ -12,8 +12,8 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.annotation.LooperMode
+import uk.ac.lshtm.keppel.android.External
 import uk.ac.lshtm.keppel.android.Keppel
-import uk.ac.lshtm.keppel.android.OdkExternal
 import uk.ac.lshtm.keppel.core.Scanner
 
 @RunWith(RobolectricTestRunner::class)
@@ -32,7 +32,7 @@ class ScanActivityTest {
 
         activityController = Robolectric.buildActivity(
             ScanActivity::class.java,
-            Intent().also { it.action = OdkExternal.ACTION_SCAN }
+            Intent().also { it.action = External.ACTION_SCAN }
         )
         activity = activityController.setup().get()
     }

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScanActivityTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScanActivityTest.kt
@@ -1,6 +1,7 @@
 package uk.ac.lshtm.keppel.android.scanning
 
 import android.content.Context
+import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Before
 import org.junit.Test
@@ -12,6 +13,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.annotation.LooperMode
 import uk.ac.lshtm.keppel.android.Keppel
+import uk.ac.lshtm.keppel.android.OdkExternal
 import uk.ac.lshtm.keppel.core.Scanner
 
 @RunWith(RobolectricTestRunner::class)
@@ -28,7 +30,10 @@ class ScanActivityTest {
             .setDependencies(availableScanners = listOf(FakeScannerFactory(fakeScanner)))
         ApplicationProvider.getApplicationContext<Keppel>().configureDefaultScanner(override = true)
 
-        activityController = Robolectric.buildActivity(ScanActivity::class.java)
+        activityController = Robolectric.buildActivity(
+            ScanActivity::class.java,
+            Intent().also { it.action = OdkExternal.ACTION_SCAN }
+        )
         activity = activityController.setup().get()
     }
 

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModelTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModelTest.kt
@@ -7,7 +7,9 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import uk.ac.lshtm.keppel.android.scanning.ScannerViewModel.ScannerState
 import uk.ac.lshtm.keppel.core.Scanner
 import uk.ac.lshtm.keppel.core.TaskRunner

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/settings/SettingsActivityTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/settings/SettingsActivityTest.kt
@@ -1,7 +1,6 @@
 package uk.ac.lshtm.keppel.android.settings
 
 import android.content.Intent
-import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withText

--- a/Android/biomini/src/main/AndroidManifest.xml
+++ b/Android/biomini/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest />

--- a/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
+++ b/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
@@ -10,7 +10,6 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import android.os.Build
 import android.os.Looper
-import android.os.PowerManager
 import android.util.Log
 import com.suprema.BioMiniFactory
 import com.suprema.CaptureResponder

--- a/Android/core/src/main/java/uk/ac/lshtm/keppel/core/HexExtensions.kt
+++ b/Android/core/src/main/java/uk/ac/lshtm/keppel/core/HexExtensions.kt
@@ -1,7 +1,5 @@
 package uk.ac.lshtm.keppel.core
 
-import java.lang.NumberFormatException
-
 fun ByteArray.toHexString() = asUByteArray().joinToString("") { it.toString(16).padStart(2, '0') }
 fun String.toHexString() = this.toByteArray().toHexString()
 fun String.fromHex(): ByteArray? {

--- a/Android/mantramfs100/src/main/AndroidManifest.xml
+++ b/Android/mantramfs100/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest />

--- a/Android/mantramfs100/src/test/java/uk/ac/lshtm/keppel/mantramfs100/MFS100ScannerTest.kt
+++ b/Android/mantramfs100/src/test/java/uk/ac/lshtm/keppel/mantramfs100/MFS100ScannerTest.kt
@@ -13,7 +13,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.robolectric.RobolectricTestRunner
 import uk.ac.lshtm.keppel.core.CaptureResult
 import uk.ac.lshtm.keppel.core.toHexString


### PR DESCRIPTION
This adds a "fast mode" that skips straight to capturing (without needing a "Capture"/"Match") button. It can be enable by passing a `uk.ac.lshtm.keppel.android.fast` param. For example, a `SCAN` single return `appearance` would be:

```
ex:uk.ac.lshtm.keppel.android.SCAN(uk.ac.lshtm.keppel.android.fast="true")
```
