### PR TITLE
Fix `null` value extras case

### DIFF
--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/OdkExternal.kt
@@ -7,10 +7,6 @@ object OdkExternal {
     const val PARAM_INPUT_VALUE = "value"
     const val PARAM_RETURN_VALUE = "value"
 
-    fun isSingleReturn(odkExternalRequest: OdkExternalRequest): Boolean {
-        return odkExternalRequest.inputValue != null
-    }
-
     fun buildSingleReturnIntent(double: Double): Intent {
         return Intent().also {
             it.putExtra(PARAM_RETURN_VALUE, double)
@@ -24,7 +20,7 @@ object OdkExternal {
     }
 
     fun buildMultipleReturnResult(
-        params:  Map<String, String>,
+        params: Map<String, String>,
         results: Map<String, Any>
     ): Intent {
         return Intent().also {
@@ -43,10 +39,18 @@ object OdkExternal {
     }
 
     fun parseIntent(intent: Intent): OdkExternalRequest {
-        val params = intent.extras?.keySet()?.associate { Pair(it, intent.getStringExtra(it)!!) }
+        val params = intent.extras?.keySet()?.fold(emptyMap<String, String>()) { map, key ->
+            val value = intent.getStringExtra(key)
+            if (value != null) {
+                map + mapOf(key to value)
+            } else {
+                map
+            }
+        }
 
         return OdkExternalRequest(
             intent.action!!,
+            intent.extras?.containsKey(PARAM_INPUT_VALUE) ?: false,
             intent.getStringExtra(PARAM_INPUT_VALUE),
             params ?: emptyMap()
         )
@@ -55,6 +59,7 @@ object OdkExternal {
 
 data class OdkExternalRequest(
     val action: String,
+    val isSingleReturn: Boolean,
     val inputValue: String?,
     val params: Map<String, String>
 )

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -143,7 +143,7 @@ class ScanActivity : AppCompatActivity() {
         odkExternalRequest: OdkExternalRequest,
         capture: CaptureResult
     ): Intent {
-        return if (OdkExternal.isSingleReturn(odkExternalRequest)) {
+        return if (odkExternalRequest.isSingleReturn) {
             OdkExternal.buildSingleReturnIntent(capture.isoTemplate)
         } else {
             OdkExternal.buildMultipleReturnResult(
@@ -160,7 +160,7 @@ class ScanActivity : AppCompatActivity() {
         score: Double,
         capture: CaptureResult
     ): Intent {
-        return if (OdkExternal.isSingleReturn(odkExternalRequest)) {
+        return if (odkExternalRequest.isSingleReturn) {
             OdkExternal.buildSingleReturnIntent(score)
         } else {
             OdkExternal.buildMultipleReturnResult(

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/OdkExternalTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/OdkExternalTest.kt
@@ -1,13 +1,27 @@
 package uk.ac.lshtm.keppel.android
 
+import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.Serializable
 
 @RunWith(AndroidJUnit4::class)
 class OdkExternalTest {
+
+    @Test
+    fun `parse handles single return intents with null values correctly`() {
+        val intent = Intent().also {
+            it.action = "blah"
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, null as Serializable?)
+        }
+
+        val request = OdkExternal.parseIntent(intent)
+        assertThat(request.isSingleReturn, equalTo(true))
+        assertThat(request.inputValue, equalTo(null))
+    }
 
     @Test
     fun `buildMultipleReturnResult does not include result when key is not in input intent`() {


### PR DESCRIPTION
This fixes a crash when Collect tries to send a `SCAN`/`MATCH` request for questions that currently have no (`null`) answer.