### PR TITLE
Review and tweak BioMini scanner code

### DIFF
--- a/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
+++ b/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
@@ -194,16 +194,7 @@ class BioMiniScanner(private val context: Context) : Scanner {
             if (_device.getVendorId() == 0x16d1) {
                 Log.d(TAG, "found suprema usb device")
                 mUsbDevice = _device
-                if (usbManager.hasPermission(_device) == false) {
-                    Log.d(TAG, "This device need to Usb Permission!")
-                    mHandler.sendEmptyMessage(REQUEST_USB_PERMISSION)
-                } else {
-                    Log.d(
-                        TAG,
-                        "This device alread have USB permission! please activate this device.",
-                    )
-                    mHandler.sendEmptyMessage(ACTIVATE_USB_DEVICE)
-                }
+                mHandler.sendEmptyMessage(REQUEST_USB_PERMISSION)
             } else {
                 Log.d(TAG, "This device is not suprema device!  : " + _device.getVendorId())
             }

--- a/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
+++ b/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
@@ -69,7 +69,7 @@ class BioMiniScanner(private val context: Context) : Scanner {
                 }
                 UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
                     Log.d(TAG, "ACTION_USB_DEVICE_ATTACHED")
-                    initUsbDevice()
+                    findAndRequestPermission()
                 }
                 UsbManager.ACTION_USB_DEVICE_DETACHED -> {
                     Log.d(TAG, "ACTION_USB_DEVICE_DETACHED")
@@ -79,18 +79,6 @@ class BioMiniScanner(private val context: Context) : Scanner {
                 else -> {}
             }
         }
-    }
-
-    private fun initUsbListener() {
-        Log.d(TAG, "start initUsbListener!")
-        context.registerReceiver(
-            mUsbReceiver,
-            IntentFilter(ACTION_USB_PERMISSION),
-        )
-        val attachfilter = IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED)
-        context.registerReceiver(mUsbReceiver, attachfilter)
-        val detachfilter = IntentFilter(UsbManager.ACTION_USB_DEVICE_DETACHED)
-        context.registerReceiver(mUsbReceiver, detachfilter)
     }
 
     var mHandler: android.os.Handler = object : android.os.Handler(Looper.getMainLooper()) {
@@ -117,41 +105,6 @@ class BioMiniScanner(private val context: Context) : Scanner {
                     )
                     mUsbManager?.requestPermission(mUsbDevice, mPermissionIntent)
                 }
-            }
-        }
-    }
-
-    fun initUsbDevice() {
-        Log.d("TAG", "start!")
-        val usbManager = mUsbManager
-        if (usbManager == null) {
-            Log.d(TAG, "mUsbManager is null")
-            return
-        }
-        if (mUsbDevice != null) {
-            Log.d(TAG, "usbdevice is not null!")
-            return
-        }
-        val deviceList: java.util.HashMap<String, UsbDevice> = usbManager.getDeviceList()
-        val deviceIter: Iterator<UsbDevice> = deviceList.values.iterator()
-        while (deviceIter.hasNext()) {
-            val _device: UsbDevice = deviceIter.next()
-            Log.d(TAG, "device id" + _device.getVendorId())
-            if (_device.getVendorId() == 0x16d1) {
-                Log.d(TAG, "found suprema usb device")
-                mUsbDevice = _device
-                if (usbManager.hasPermission(_device) == false) {
-                    Log.d(TAG, "This device need to Usb Permission!")
-                    mHandler.sendEmptyMessage(REQUEST_USB_PERMISSION)
-                } else {
-                    Log.d(
-                        TAG,
-                        "This device alread have USB permission! please activate this device.",
-                    )
-                    mHandler.sendEmptyMessage(ACTIVATE_USB_DEVICE)
-                }
-            } else {
-                Log.d(TAG, "This device is not suprema device!  : " + _device.getVendorId())
             }
         }
     }
@@ -206,9 +159,55 @@ class BioMiniScanner(private val context: Context) : Scanner {
             mUsbManager =
                 context.getSystemService(Context.USB_SERVICE) as UsbManager
         }
-        initUsbListener()
-        initUsbDevice()
+
+        registerBroadcastReceiver()
+        findAndRequestPermission()
         return this
+    }
+
+    private fun registerBroadcastReceiver() {
+        Log.d(TAG, "start initUsbListener!")
+
+        context.registerReceiver(mUsbReceiver, IntentFilter(ACTION_USB_PERMISSION))
+        val attachfilter = IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED)
+        context.registerReceiver(mUsbReceiver, attachfilter)
+        val detachfilter = IntentFilter(UsbManager.ACTION_USB_DEVICE_DETACHED)
+        context.registerReceiver(mUsbReceiver, detachfilter)
+    }
+
+    private fun findAndRequestPermission() {
+        Log.d("TAG", "start!")
+        val usbManager = mUsbManager
+        if (usbManager == null) {
+            Log.d(TAG, "mUsbManager is null")
+            return
+        }
+        if (mUsbDevice != null) {
+            Log.d(TAG, "usbdevice is not null!")
+            return
+        }
+        val deviceList: java.util.HashMap<String, UsbDevice> = usbManager.getDeviceList()
+        val deviceIter: Iterator<UsbDevice> = deviceList.values.iterator()
+        while (deviceIter.hasNext()) {
+            val _device: UsbDevice = deviceIter.next()
+            Log.d(TAG, "device id" + _device.getVendorId())
+            if (_device.getVendorId() == 0x16d1) {
+                Log.d(TAG, "found suprema usb device")
+                mUsbDevice = _device
+                if (usbManager.hasPermission(_device) == false) {
+                    Log.d(TAG, "This device need to Usb Permission!")
+                    mHandler.sendEmptyMessage(REQUEST_USB_PERMISSION)
+                } else {
+                    Log.d(
+                        TAG,
+                        "This device alread have USB permission! please activate this device.",
+                    )
+                    mHandler.sendEmptyMessage(ACTIVATE_USB_DEVICE)
+                }
+            } else {
+                Log.d(TAG, "This device is not suprema device!  : " + _device.getVendorId())
+            }
+        }
     }
 
     override fun onDisconnect(onDisconnected: () -> Unit) {

--- a/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
+++ b/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
@@ -37,7 +37,7 @@ class BioMiniScanner(private val context: Context) : Scanner {
     private val MAKE_TOAST = BASE_EVENT + 11
     private val SHOW_CAPTURE_IMAGE_DEVICE = BASE_EVENT + 12
 
-    private val ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION"
+    private val ACTION_USB_PERMISSION = "uk.ac.lshtm.keppel.biomini.USB_PERMISSION"
 
     var mUsbDevice: UsbDevice? = null
     private var mUsbManager: UsbManager? = null


### PR DESCRIPTION
I've done short review of the BioMini scanner code and made a couple of changes to things that looked suspicious to me:

- The permission request action was `"com.android.example.USB_PERMISSION"` which is likely some unchanged example code. This might cause weird interactions with any other apps that interact with BioMini scanners (that could use the same action identifier). I've now made this unique to Keppel.
- The `connect()` implementation was simplified to always go through the permissions flow to simplify the paths to connecting the scanner. If the app already has permission, we still end up going through the "granted" path. This removes any risk that we read an incorrect/out of date permission state and then try and connect to a scanner we don't permission to access.

There's like more improvements we could make here: the use of a `Handler` might not actually be needed (or could be reduced) and the anonymous class `BroadcastReceiver` could be pulled out to a concrete class. There's a lot of shared state manipulated by these objects which is firstly hard to reason about and secondly potentially a source of problems.
