### PR TITLE
Don't show settings whenever scanner is connected

### DIFF
--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -22,12 +22,6 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
-            </intent-filter>
-
-            <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" android:resource="@xml/usb_device_filter" />
         </activity>
 
         <activity
@@ -44,6 +38,17 @@
                 <action android:name="uk.ac.lshtm.keppel.android.MATCH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+        </activity>
+
+        <activity android:name="uk.ac.lshtm.keppel.android.settings.UsbDeviceAttachedActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/usb_device_filter" />
         </activity>
     </application>
 </manifest>

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -44,7 +44,8 @@
 
         <activity android:name="uk.ac.lshtm.keppel.android.settings.UsbDeviceAttachedActivity"
             android:exported="true"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:taskAffinity="">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Keppel">
 
+
+        <!--  directBootAware is required for USB permission requests to work between boots -->
         <activity
             android:name="uk.ac.lshtm.keppel.android.settings.SettingsActivity"
             android:directBootAware="true"

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -41,7 +41,8 @@
         </activity>
 
         <activity android:name="uk.ac.lshtm.keppel.android.settings.UsbDeviceAttachedActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/settings/UsbDeviceAttachedActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/settings/UsbDeviceAttachedActivity.kt
@@ -2,10 +2,15 @@ package uk.ac.lshtm.keppel.android.settings
 
 import android.app.Activity
 import android.os.Bundle
+import android.widget.Toast
+import uk.ac.lshtm.keppel.android.R
 
 class UsbDeviceAttachedActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        Toast.makeText(this, R.string.scanner_connected, Toast.LENGTH_LONG).show()
+        finish()
     }
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/settings/UsbDeviceAttachedActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/settings/UsbDeviceAttachedActivity.kt
@@ -1,0 +1,11 @@
+package uk.ac.lshtm.keppel.android.settings
+
+import android.app.Activity
+import android.os.Bundle
+
+class UsbDeviceAttachedActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+}

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="input_missing_error">\"%1$s\" is missing!</string>
     <string name="ok">Ok</string>
     <string name="cancel">Cancel</string>
+    <string name="scanner_connected">USB scanner connected</string>
 </resources>

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/settings/UsbDeviceAttachedActivityTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/settings/UsbDeviceAttachedActivityTest.kt
@@ -1,0 +1,34 @@
+package uk.ac.lshtm.keppel.android.settings
+
+import android.app.Application
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowToast
+import uk.ac.lshtm.keppel.android.R
+
+@RunWith(AndroidJUnit4::class)
+class UsbDeviceAttachedActivityTest {
+
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @Test
+    fun `closes immediately`() {
+        ActivityScenario.launch(UsbDeviceAttachedActivity::class.java).use {
+            assertThat(it.state, equalTo(Lifecycle.State.DESTROYED))
+        }
+    }
+
+    @Test
+    fun `shows toast`() {
+        ActivityScenario.launch(UsbDeviceAttachedActivity::class.java).use {
+            val latestToast = ShadowToast.getTextOfLatestToast()
+            assertThat(latestToast, equalTo(application.getString(R.string.scanner_connected)))
+        }
+    }
+}


### PR DESCRIPTION
Closes #17

Instead of showing settings, just a toast will now be shown when a recognized scanner is connected.