### PR TITLE
Improve and handle BioMini timeout

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'org.robolectric:robolectric:4.9'
     testImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    testImplementation 'org.mockito:mockito-core:5.4.0'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:5.4.0"
     testImplementation 'androidx.arch.core:core-testing:2.2.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -89,7 +89,7 @@ class MatchActionTest {
         val result = rule.launchAction(intent, ConnectingPage()) {
             it.connect(fakeScanner, MatchPage()).clickMatch()
             fakeScanner.returnTemplate("scanned", 1)
-            ErrorDialogPage(R.string.input_format_error).assert().clickOk()
+            ErrorDialogPage(R.string.input_error).assert().clickOk()
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
@@ -112,7 +112,7 @@ class MatchActionTest {
         val result = rule.launchAction(intent, ConnectingPage()) {
             it.connect(fakeScanner, MatchPage()).clickMatch()
             fakeScanner.returnTemplate("scanned", 1)
-            ErrorDialogPage(R.string.input_format_error).assert().clickOk()
+            ErrorDialogPage(R.string.input_error).assert().clickOk()
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -108,7 +108,10 @@ class ScanActionTest {
         val result = rule.launchAction(intent, ConnectingPage()) {
             it.connect(fakeScanner, CapturingPage())
             fakeScanner.failToCapture()
-            ErrorDialogPage(R.string.no_capture_result_error).assert().clickOk()
+
+            val errorDialog = ErrorDialogPage(R.string.no_capture_result_error).assert()
+            assertThat(fakeScanner.capturing, equalTo(false))
+            errorDialog.clickOk()
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/ScanActionTest.kt
@@ -14,6 +14,7 @@ import uk.ac.lshtm.keppel.android.support.KeppelTestRule
 import uk.ac.lshtm.keppel.android.support.pages.CapturePage
 import uk.ac.lshtm.keppel.android.support.pages.CapturingPage
 import uk.ac.lshtm.keppel.android.support.pages.ConnectingPage
+import uk.ac.lshtm.keppel.android.support.pages.ErrorDialogPage
 import uk.ac.lshtm.keppel.core.toHexString
 
 @RunWith(AndroidJUnit4::class)
@@ -95,5 +96,21 @@ class ScanActionTest {
             extras.getString(OdkExternal.PARAM_RETURN_VALUE),
             equalTo("scanned".toHexString())
         )
+    }
+
+    @Test
+    fun withFastMode_whenCapturingFails_showsAnError() {
+        val intent = Intent(External.ACTION_SCAN).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
+            it.putExtra(External.PARAM_FAST, "true")
+        }
+
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, CapturingPage())
+            fakeScanner.failToCapture()
+            ErrorDialogPage(R.string.no_capture_result_error).assert().clickOk()
+        }
+
+        assertThat(result.resultCode, equalTo(Activity.RESULT_CANCELED))
     }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/FakeScannerFactory.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/FakeScannerFactory.kt
@@ -24,8 +24,9 @@ class FakeScanner : Scanner {
     private var returnNfiq: Int? = null
     private var fail = false
 
-    private var capturing = false
     private var connected = false
+    var capturing = false
+        private set
 
     private var onConnected: () -> Unit = {}
 

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/FakeScannerFactory.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/support/FakeScannerFactory.kt
@@ -22,6 +22,7 @@ class FakeScanner : Scanner {
 
     private var returnTemplate: String? = null
     private var returnNfiq: Int? = null
+    private var fail = false
 
     private var capturing = false
     private var connected = false
@@ -43,13 +44,20 @@ class FakeScanner : Scanner {
         }
 
         capturing = true
-        TaskRunnerIdlingResource.nonBlockingWait { capturing && returnTemplate == null }
+        TaskRunnerIdlingResource.nonBlockingWait {
+            capturing && returnTemplate == null && !fail
+        }
 
         if (capturing) {
             capturing = false
-            val result = CaptureResult(returnTemplate!!.toHexString(), returnNfiq!!)
-            returnTemplate = null
-            return result
+            if (!fail) {
+                val result = CaptureResult(returnTemplate!!.toHexString(), returnNfiq!!)
+                returnTemplate = null
+                return result
+            } else {
+                fail = false
+                return null
+            }
         } else {
             return null
         }
@@ -66,6 +74,10 @@ class FakeScanner : Scanner {
     fun returnTemplate(template: String, nfiq: Int) {
         returnTemplate = template
         returnNfiq = nfiq
+    }
+
+    fun failToCapture() {
+        fail = true
     }
 
     fun connect() {

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -124,9 +124,16 @@ class ScanActivity : AppCompatActivity() {
                 returnResult(buildScanReturn(request.odkExternalRequest, result.captureResult))
             }
 
-            else -> {
+            is ScannerViewModel.Result.InputError -> {
                 MaterialAlertDialogBuilder(this)
-                    .setMessage(R.string.input_format_error)
+                    .setMessage(R.string.input_error)
+                    .setPositiveButton(R.string.ok) { _, _ -> finish() }
+                    .show()
+            }
+
+            is ScannerViewModel.Result.NoCaptureResultError -> {
+                MaterialAlertDialogBuilder(this)
+                    .setMessage(R.string.no_capture_result_error)
                     .setPositiveButton(R.string.ok) { _, _ -> finish() }
                     .show()
             }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -47,15 +47,15 @@ class ScannerViewModel(
                     if (score != null) {
                         _result.postValue(Result.Match(score, capture))
                     } else {
-                        _result.postValue(Result.Error)
+                        _result.postValue(Result.InputError)
                     }
                 } else {
-                    _result.postValue(Result.Error)
+                    _result.postValue(Result.InputError)
                 }
             } else if (capture != null) {
                 _result.postValue(Result.Scan(capture))
             } else {
-                _result.postValue(null)
+                _result.postValue(Result.NoCaptureResultError)
             }
 
             _scannerState.postValue(Connected)
@@ -74,7 +74,8 @@ class ScannerViewModel(
     sealed class Result {
         data class Scan(val captureResult: CaptureResult) : Result()
         data class Match(val score: Double, val captureResult: CaptureResult) : Result()
-        object Error : Result()
+        object InputError : Result()
+        object NoCaptureResultError : Result()
     }
 
     sealed class ScannerState {

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScannerViewModel.kt
@@ -15,7 +15,9 @@ import uk.ac.lshtm.keppel.core.fromHex
 class ScannerViewModel(
     private val scanner: Scanner,
     private val matcher: Matcher,
-    private val taskRunner: TaskRunner
+    private val taskRunner: TaskRunner,
+    private val inputTemplate: String? = null,
+    private val fast: Boolean = false
 ) : ViewModel() {
 
     private val _scannerState = MutableLiveData<ScannerState>(Disconnected)
@@ -27,6 +29,10 @@ class ScannerViewModel(
     init {
         scanner.connect {
             _scannerState.value = Connected
+
+            if (fast) {
+                capture()
+            }
         }
 
         scanner.onDisconnect {
@@ -34,7 +40,7 @@ class ScannerViewModel(
         }
     }
 
-    fun capture(inputTemplate: String? = null) {
+    fun capture() {
         _scannerState.value = Scanning
 
         taskRunner.execute {

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -8,7 +8,8 @@
     <string name="change_scanner">Change scanner</string>
     <string name="app_version">App version</string>
     <string name="match">Match</string>
-    <string name="input_format_error">Input template is not in the correct format!</string>
+    <string name="input_error">Input template is not in the correct format!</string>
+    <string name="no_capture_result_error">No capture result from scanner!</string>
     <string name="input_missing_error">\"%1$s\" is missing!</string>
     <string name="ok">Ok</string>
     <string name="cancel">Cancel</string>

--- a/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
+++ b/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
@@ -266,30 +266,35 @@ class BioMiniScanner(private val context: Context) : Scanner {
         }
     }
 
-    private fun setTemplateType() {
-        val currentDevice = mCurrentDevice
-        if (currentDevice != null) {
-            val tmp_type = IBioMiniDevice.TemplateType.ISO19794_2.value()
-            currentDevice.setParameter(
-                IBioMiniDevice.Parameter(
-                    IBioMiniDevice.ParameterType.TEMPLATE_TYPE,
-                    tmp_type.toLong(),
-                ),
+    private fun setParameters(iBioMiniDevice: IBioMiniDevice) {
+        iBioMiniDevice.setParameter(
+            IBioMiniDevice.Parameter(
+                IBioMiniDevice.ParameterType.TEMPLATE_TYPE,
+                IBioMiniDevice.TemplateType.ISO19794_2.value().toLong(),
+            ),
+        )
+
+        iBioMiniDevice.setParameter(
+            IBioMiniDevice.Parameter(
+                IBioMiniDevice.ParameterType.TIMEOUT,
+                30000 // 30 seconds
             )
-        }
+        )
     }
 
     override fun capture(): CaptureResult? {
-        val latch = CountDownLatch(1)
-        setTemplateType()
-        doSingleCapture(latch)
-        latch.await()
+        return mCurrentDevice?.let {
+            val latch = CountDownLatch(1)
+            setParameters(it)
+            doSingleCapture(latch)
+            latch.await()
 
-        val tmp = mTemplateData
-        return if (tmp?.data != null) {
-            CaptureResult(tmp.data.toHexString(), mFpQuality ?: 0)
-        } else {
-            null
+            val tmp = mTemplateData
+            return if (tmp?.data != null) {
+                CaptureResult(tmp.data.toHexString(), mFpQuality ?: 0)
+            } else {
+                null
+            }
         }
     }
 

--- a/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
+++ b/Android/biomini/src/main/java/uk/ac/lshtm/keppel/biomini/BioMiniScanner.kt
@@ -243,22 +243,7 @@ class BioMiniScanner(private val context: Context) : Scanner {
             }
 
             override fun onCaptureError(context: Any?, errorCode: Int, error: String) {
-                // TODO error handling
-                //            if (errorCode == IBioMiniDevice.ErrorCode.CTRL_ERR_IS_CAPTURING.value()) {
-                //                setLogInTextView("Other capture function is running. abort capture function first!")
-                //            } else if (errorCode == IBioMiniDevice.ErrorCode.CTRL_ERR_CAPTURE_ABORTED.value()) {
-                //                Log.d(TAG, "CTRL_ERR_CAPTURE_ABORTED occured.")
-                //            } else if (errorCode == IBioMiniDevice.ErrorCode.CTRL_ERR_FAKE_FINGER.value()) {
-                //                setLogInTextView("Fake Finger Detected")
-                //                if (mCurrentDevice != null && mCurrentDevice.getLfdLevel() > 0) {
-                //                    setLogInTextView("LFD SCORE : " + mCurrentDevice.getLfdScoreFromCapture())
-                //                }
-                //            } else {
-                //                setLogInTextView(mCaptureOption.captureFuntion.name() + " is fail by " + error)
-                //                setLogInTextView("Please try again.")
-                //            }
-                //            mViewPager.setUserInputEnabled(true)
-                //            setUiClickable(true)
+                latch.countDown()
             }
         }
     }


### PR DESCRIPTION
Closes #24

This ups the timeout when using the BioMini scanner to 30 seconds and ensures that Keppel can handle the timeout (and other errors). It also fixes a bug where scanning would resume automatically after an error occurred in `fast` mode which might have been leading to problems with scanner lifecycle.

One thing to note is that navigating away from the app while scanning and the returning will cause an error (and then will return to Collect). This feels like an acceptable quirk for now and can always be improved upon later. I'm working on the assumption that there will be no reason to leave Keppel during scanning in most use cases.