### PR TITLE
Add multi input version of MATCH

### DIFF
--- a/ACTIONS.md
+++ b/ACTIONS.md
@@ -1,0 +1,77 @@
+# Actions
+
+Keppel is designed to be used as an ["external app" for ODK Collect](https://docs.getodk.org/collect-external-apps/). This means it supports various "actions" that forms can use to trigger different features.
+
+## Scan
+
+The scan action (`uk.ac.lshtm.keppel.android.SCAN`) returns a hex encoded template based on a scanned finger. 
+
+An optional `uk.ac.lshtm.keppel.android.return_iso_template.fast` parameter can be passed as `true` to have Keppel start scanning immediately rather than needing the enumerator or participant to press "Capture".
+
+### Single field example
+
+In `appearance`:
+
+```
+ex:uk.ac.lshtm.keppel.android.SCAN
+```
+
+### Multiple field example
+
+In the group `body::intent`:
+
+```
+ex:uk.ac.lshtm.keppel.android.SCAN(uk.ac.lshtm.keppel.android.return_iso_template=my_iso_template_field, uk.ac.lshtm.keppel.android.return_nfiq=my_nfiq_field)
+```
+
+The returned template or NFIQ can be included/omitted by including/omitting the corresponding parameter.
+
+## Match
+
+The match action (`uk.ac.lshtm.keppel.android.MATCH`) takes in a hex encoded template and returns a score based on matching against a capture.
+
+An optional `uk.ac.lshtm.keppel.android.return_iso_template.fast` parameter can be passed as `true` to have Keppel start scanning immediately rather than needing the enumerator or participant to press "Capture".
+
+### Single field example
+
+In `appearance`:
+
+```
+ex:uk.ac.lshtm.keppel.android.MATCH(uk.ac.lshtm.keppel.android.iso_template=iso_template_field)
+```
+
+### Multiple field example
+
+In the group `body::intent`:
+
+```
+ex:uk.ac.lshtm.keppel.android.MATCH(uk.ac.lshtm.keppel.android.iso_template=iso_template_field, 
+uk.ac.lshtm.keppel.android.return_score=my_score_field, uk.ac.lshtm.keppel.android.return_iso_template=my_iso_template_field, uk.ac.lshtm.keppel.android.return_nfiq=my_nfiq_field)
+```
+
+The returned score, template or NFIQ can be included/omitted by including/omitting the corresponding parameter.
+
+## Multi-match
+
+The multi-match (`uk.ac.lshtm.keppel.android.MULTI_MATCH`) action takes multiple hex encoded template parameters and returns the best (max) score matching against a capture.
+
+An optional `uk.ac.lshtm.keppel.android.return_iso_template.fast` parameter can be passed as `true` to have Keppel start scanning immediately rather than needing the enumerator or participant to press "Capture".
+
+### Single field example
+
+In `appearance`:
+
+```
+ex:uk.ac.lshtm.keppel.android.MULTI_MATCH(uk.ac.lshtm.keppel.android.iso_template_1=iso_template_field_1, uk.ac.lshtm.keppel.android.iso_template_2=iso_template_field_2)
+```
+
+### Multiple field example
+
+In the group `body::intent`:
+
+```
+ex:uk.ac.lshtm.keppel.android.MATCH(uk.ac.lshtm.keppel.android.iso_template_1=iso_template_field_1, uk.ac.lshtm.keppel.android.iso_template_2=iso_template_field_2, 
+uk.ac.lshtm.keppel.android.return_score=my_score_field, uk.ac.lshtm.keppel.android.return_iso_template=my_iso_template_field, uk.ac.lshtm.keppel.android.return_nfiq=my_nfiq_field)
+```
+
+The returned score, template or NFIQ can be included/omitted by including/omitting the corresponding parameter.

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -157,29 +157,4 @@ class MatchActionTest {
             equalTo(96.0)
         )
     }
-
-    @Test
-    fun whenPassedAListOfTemplates_capturesAndReturnsMaxMatchScore() {
-        fakeMatcher.addScore("blah1", "scanned", 94.0)
-        fakeMatcher.addScore("blah2", "scanned", 96.0)
-        fakeMatcher.addScore("blah3", "scanned", 95.0)
-
-        val intent = Intent(External.ACTION_MATCH).also {
-            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
-            it.putExtra(External.paramIsoTemplate(1), "blah1".toHexString())
-            it.putExtra(External.paramIsoTemplate(2), "blah2".toHexString())
-            it.putExtra(External.paramIsoTemplate(3) + "_3", "blah3".toHexString())
-        }
-
-        val result = rule.launchAction(intent, ConnectingPage()) {
-            it.connect(fakeScanner, MatchPage()).clickMatch()
-            fakeScanner.returnTemplate("scanned", 1)
-        }
-
-        val extras = result.resultData.extras!!
-        assertThat(
-            extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),
-            equalTo(96.0)
-        )
-    }
 }

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -47,11 +47,7 @@ class MatchActionTest {
     @Test
     fun clickingMatch_capturesAndReturnsMatchScore() {
         val existingTemplate = "blah"
-        fakeMatcher.addScore(
-            existingTemplate,
-            "scanned",
-            96.0
-        )
+        fakeMatcher.addScore(existingTemplate, "scanned", 96.0)
 
         val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
@@ -75,11 +71,7 @@ class MatchActionTest {
     @Test
     fun clickingMatch_whenExistingTemplateIsNotHexEncoded_showsAnError() {
         val existingTemplate = "blah"
-        fakeMatcher.addScore(
-            existingTemplate,
-            "scanned",
-            96.0
-        )
+        fakeMatcher.addScore(existingTemplate, "scanned", 96.0)
 
         val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
@@ -98,11 +90,7 @@ class MatchActionTest {
     @Test
     fun clickingMatch_whenMatchFails_showsAnError() {
         val existingTemplate = "blah"
-        fakeMatcher.addScore(
-            existingTemplate,
-            "scanned",
-            null
-        )
+        fakeMatcher.addScore(existingTemplate, "scanned", null)
 
         val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
@@ -121,11 +109,7 @@ class MatchActionTest {
     @Test
     fun clickingMatch_whenReturnValuesSpecified_capturesAndReturnsThoseValues() {
         val existingTemplate = "blah"
-        fakeMatcher.addScore(
-            existingTemplate,
-            "scanned",
-            96.0
-        )
+        fakeMatcher.addScore(existingTemplate, "scanned", 96.0)
 
         val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(External.PARAM_ISO_TEMPLATE, existingTemplate.toHexString())
@@ -153,11 +137,7 @@ class MatchActionTest {
     @Test
     fun withFastMode_capturesAndReturnsMatchScore() {
         val existingTemplate = "blah"
-        fakeMatcher.addScore(
-            existingTemplate,
-            "scanned",
-            96.0
-        )
+        fakeMatcher.addScore(existingTemplate, "scanned", 96.0)
 
         val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
@@ -171,6 +151,31 @@ class MatchActionTest {
         }
 
         assertThat(result.resultCode, equalTo(Activity.RESULT_OK))
+        val extras = result.resultData.extras!!
+        assertThat(
+            extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),
+            equalTo(96.0)
+        )
+    }
+
+    @Test
+    fun whenPassedAListOfTemplates_capturesAndReturnsMaxMatchScore() {
+        fakeMatcher.addScore("blah1", "scanned", 94.0)
+        fakeMatcher.addScore("blah2", "scanned", 96.0)
+        fakeMatcher.addScore("blah3", "scanned", 95.0)
+
+        val intent = Intent(External.ACTION_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
+            it.putExtra(External.PARAM_ISO_TEMPLATE + "_1", "blah1".toHexString())
+            it.putExtra(External.PARAM_ISO_TEMPLATE + "_2", "blah2".toHexString())
+            it.putExtra(External.PARAM_ISO_TEMPLATE + "_3", "blah3".toHexString())
+        }
+
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, MatchPage()).clickMatch()
+            fakeScanner.returnTemplate("scanned", 1)
+        }
+
         val extras = result.resultData.extras!!
         assertThat(
             extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MatchActionTest.kt
@@ -166,9 +166,9 @@ class MatchActionTest {
 
         val intent = Intent(External.ACTION_MATCH).also {
             it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
-            it.putExtra(External.PARAM_ISO_TEMPLATE + "_1", "blah1".toHexString())
-            it.putExtra(External.PARAM_ISO_TEMPLATE + "_2", "blah2".toHexString())
-            it.putExtra(External.PARAM_ISO_TEMPLATE + "_3", "blah3".toHexString())
+            it.putExtra(External.paramIsoTemplate(1), "blah1".toHexString())
+            it.putExtra(External.paramIsoTemplate(2), "blah2".toHexString())
+            it.putExtra(External.paramIsoTemplate(3) + "_3", "blah3".toHexString())
         }
 
         val result = rule.launchAction(intent, ConnectingPage()) {

--- a/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MultiMatchAction.kt
+++ b/Android/app/src/androidTest/java/uk/ac/lshtm/keppel/android/MultiMatchAction.kt
@@ -1,0 +1,51 @@
+package uk.ac.lshtm.keppel.android
+
+import android.content.Intent
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Rule
+import org.junit.Test
+import uk.ac.lshtm.keppel.android.support.FakeMatcher
+import uk.ac.lshtm.keppel.android.support.FakeScanner
+import uk.ac.lshtm.keppel.android.support.FakeScannerFactory
+import uk.ac.lshtm.keppel.android.support.KeppelTestRule
+import uk.ac.lshtm.keppel.android.support.pages.ConnectingPage
+import uk.ac.lshtm.keppel.android.support.pages.MatchPage
+import uk.ac.lshtm.keppel.core.toHexString
+
+class MultiMatchAction {
+
+    private val fakeScanner = FakeScanner()
+    private val fakeMatcher = FakeMatcher()
+
+    @get:Rule
+    val rule = KeppelTestRule(
+        scanners = listOf(FakeScannerFactory(fakeScanner)),
+        matcher = fakeMatcher
+    )
+
+    @Test
+    fun capturesAndReturnsMaxMatchScore() {
+        fakeMatcher.addScore("blah1", "scanned", 94.0)
+        fakeMatcher.addScore("blah2", "scanned", 96.0)
+        fakeMatcher.addScore("blah3", "scanned", 95.0)
+
+        val intent = Intent(External.ACTION_MULTI_MATCH).also {
+            it.putExtra(OdkExternal.PARAM_INPUT_VALUE, "foo")
+            it.putExtra(External.paramIsoTemplate(1), "blah1".toHexString())
+            it.putExtra(External.paramIsoTemplate(2), "blah2".toHexString())
+            it.putExtra(External.paramIsoTemplate(3) + "_3", "blah3".toHexString())
+        }
+
+        val result = rule.launchAction(intent, ConnectingPage()) {
+            it.connect(fakeScanner, MatchPage()).clickMatch()
+            fakeScanner.returnTemplate("scanned", 1)
+        }
+
+        val extras = result.resultData.extras!!
+        assertThat(
+            extras.getDouble(OdkExternal.PARAM_RETURN_VALUE),
+            equalTo(96.0)
+        )
+    }
+}

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,11 @@
                 <action android:name="uk.ac.lshtm.keppel.android.MATCH" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="uk.ac.lshtm.keppel.android.MULTI_MATCH" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity android:name="uk.ac.lshtm.keppel.android.settings.UsbDeviceAttachedActivity"

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/External.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/External.kt
@@ -5,6 +5,7 @@ object External {
 
     const val ACTION_SCAN = "$APP_ID.SCAN"
     const val ACTION_MATCH = "$APP_ID.MATCH"
+    const val ACTION_MULTI_MATCH = "$APP_ID.MULTI_MATCH"
 
     const val PARAM_RETURN_ISO_TEMPLATE = "$APP_ID.return_iso_template"
     const val PARAM_RETURN_NFIQ = "$APP_ID.return_nfiq"

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/External.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/External.kt
@@ -10,6 +10,7 @@ object External {
     const val PARAM_RETURN_NFIQ = "$APP_ID.return_nfiq"
     const val PARAM_RETURN_SCORE = "$APP_ID.return_score"
     const val PARAM_ISO_TEMPLATE = "$APP_ID.iso_template"
+    fun paramIsoTemplate(index: Int) = "$APP_ID.iso_template_$index"
 
     const val PARAM_FAST = "$APP_ID.fast"
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -22,7 +22,11 @@ object IntentParser {
             var index = 1
             val isoTemplates = mutableListOf<String>()
             while (odkExternalRequest.params.containsKey(External.paramIsoTemplate(index))) {
-                isoTemplates.add(odkExternalRequest.params[External.paramIsoTemplate(index)]!!)
+                val paramValue = odkExternalRequest.params[External.paramIsoTemplate(index)]
+                if (paramValue!!.isNotBlank()) {
+                    isoTemplates.add(paramValue)
+                }
+
                 index += 1
             }
 

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -13,26 +13,24 @@ object IntentParser {
         return if (odkExternalRequest.action == External.ACTION_MATCH) {
             val isoTemplate = odkExternalRequest.params[External.PARAM_ISO_TEMPLATE]
 
-            if (isoTemplate != null) {
-                Request.Match(
-                    listOf(isoTemplate),
-                    fast,
-                    odkExternalRequest
-                )
-            } else {
-                var index = 1
-                val isoTemplates = mutableListOf<String>()
-                while (odkExternalRequest.params.containsKey(External.paramIsoTemplate(index))) {
-                    isoTemplates.add(odkExternalRequest.params[External.paramIsoTemplate(index)]!!)
-                    index += 1
-                }
-
-                Request.Match(
-                    isoTemplates,
-                    fast,
-                    odkExternalRequest
-                )
+            Request.Match(
+                isoTemplate?.let { listOf(isoTemplate) } ?: emptyList(),
+                fast,
+                odkExternalRequest
+            )
+        } else if (odkExternalRequest.action == External.ACTION_MULTI_MATCH) {
+            var index = 1
+            val isoTemplates = mutableListOf<String>()
+            while (odkExternalRequest.params.containsKey(External.paramIsoTemplate(index))) {
+                isoTemplates.add(odkExternalRequest.params[External.paramIsoTemplate(index)]!!)
+                index += 1
             }
+
+            Request.Match(
+                isoTemplates,
+                fast,
+                odkExternalRequest
+            )
         } else {
             Request.Scan(
                 fast,

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -11,11 +11,28 @@ object IntentParser {
         val fast = odkExternalRequest.params[External.PARAM_FAST] == "true"
 
         return if (odkExternalRequest.action == External.ACTION_MATCH) {
-            Request.Match(
-                intent.extras!!.getString(External.PARAM_ISO_TEMPLATE),
-                fast,
-                odkExternalRequest
-            )
+            val isoTemplate = odkExternalRequest.params[External.PARAM_ISO_TEMPLATE]
+
+            if (isoTemplate != null) {
+                Request.Match(
+                    listOf(isoTemplate),
+                    fast,
+                    odkExternalRequest
+                )
+            } else {
+                var index = 1
+                val isoTemplates = mutableListOf<String>()
+                while (odkExternalRequest.params.containsKey(External.PARAM_ISO_TEMPLATE + "_$index")) {
+                    isoTemplates.add(odkExternalRequest.params[External.PARAM_ISO_TEMPLATE + "_$index"]!!)
+                    index += 1
+                }
+
+                Request.Match(
+                    isoTemplates,
+                    fast,
+                    odkExternalRequest
+                )
+            }
         } else {
             Request.Scan(
                 fast,
@@ -36,7 +53,7 @@ sealed interface Request {
     ) : Request
 
     data class Match(
-        val isoTemplate: String?, override val fast: Boolean,
+        val isoTemplates: List<String>, override val fast: Boolean,
         override val odkExternalRequest: OdkExternalRequest
     ) : Request
 }

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -22,8 +22,8 @@ object IntentParser {
             } else {
                 var index = 1
                 val isoTemplates = mutableListOf<String>()
-                while (odkExternalRequest.params.containsKey(External.PARAM_ISO_TEMPLATE + "_$index")) {
-                    isoTemplates.add(odkExternalRequest.params[External.PARAM_ISO_TEMPLATE + "_$index"]!!)
+                while (odkExternalRequest.params.containsKey(External.paramIsoTemplate(index))) {
+                    isoTemplates.add(odkExternalRequest.params[External.paramIsoTemplate(index)]!!)
                     index += 1
                 }
 

--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/ScanActivity.kt
@@ -43,7 +43,7 @@ class ScanActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         if (request is Request.Match) {
-            if ((request as Request.Match).isoTemplate == null) {
+            if ((request as Request.Match).isoTemplates.isEmpty()) {
                 val error = getString(R.string.input_missing_error, External.PARAM_ISO_TEMPLATE)
 
                 MaterialAlertDialogBuilder(this)
@@ -183,11 +183,11 @@ private class ScanViewModelFactory(
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
-        val inputTemplate = request.let {
+        val inputTemplates = request.let {
             if (it is Request.Match) {
-                it.isoTemplate
+                it.isoTemplates
             } else {
-                null
+                emptyList()
             }
         }
 
@@ -195,7 +195,7 @@ private class ScanViewModelFactory(
             scanner,
             matcher,
             taskRunner,
-            inputTemplate,
+            inputTemplates,
             request.fast
         ) as T
     }

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
@@ -56,4 +56,16 @@ class IntentParserTest {
         val request = IntentParser.parse(intent)
         assertThat((request as Request.Match).isoTemplates, containsInAnyOrder("blah1"))
     }
+
+    @Test
+    fun `isoTemplates that are blank are filtered out`() {
+        val intent = Intent().also {
+            it.action = External.ACTION_MULTI_MATCH
+            it.putExtra(External.paramIsoTemplate(1), "")
+            it.putExtra(External.paramIsoTemplate(2), "blah2")
+        }
+
+        val request = IntentParser.parse(intent)
+        assertThat((request as Request.Match).isoTemplates, containsInAnyOrder("blah2"))
+    }
 }

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
@@ -3,6 +3,7 @@ package uk.ac.lshtm.keppel.android.scanning
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,5 +32,28 @@ class IntentParserTest {
 
         val request = IntentParser.parse(intent)
         assertThat(request.fast, equalTo(false))
+    }
+
+    @Test
+    fun `isoTemplates is empty when list of templates does not start at 1`() {
+        val intent = Intent().also {
+            it.action = External.ACTION_MATCH
+            it.putExtra(External.paramIsoTemplate(2), "blah")
+        }
+
+        val request = IntentParser.parse(intent)
+        assertThat((request as Request.Match).isoTemplates, equalTo(emptyList()))
+    }
+
+    @Test
+    fun `isoTemplates does not parse gaps`() {
+        val intent = Intent().also {
+            it.action = External.ACTION_MATCH
+            it.putExtra(External.paramIsoTemplate(1), "blah1")
+            it.putExtra(External.paramIsoTemplate(3), "blah3")
+        }
+
+        val request = IntentParser.parse(intent)
+        assertThat((request as Request.Match).isoTemplates, containsInAnyOrder("blah1"))
     }
 }

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
@@ -35,9 +35,9 @@ class IntentParserTest {
     }
 
     @Test
-    fun `isoTemplates is empty when list of templates does not start at 1`() {
+    fun `isoTemplates is empty when list of MULTI_MATCH templates does not start at 1`() {
         val intent = Intent().also {
-            it.action = External.ACTION_MATCH
+            it.action = External.ACTION_MULTI_MATCH
             it.putExtra(External.paramIsoTemplate(2), "blah")
         }
 
@@ -46,9 +46,9 @@ class IntentParserTest {
     }
 
     @Test
-    fun `isoTemplates does not parse gaps`() {
+    fun `isoTemplates does not parse gaps for MULTI_MATCH`() {
         val intent = Intent().also {
-            it.action = External.ACTION_MATCH
+            it.action = External.ACTION_MULTI_MATCH
             it.putExtra(External.paramIsoTemplate(1), "blah1")
             it.putExtra(External.paramIsoTemplate(3), "blah3")
         }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The images below show how this looks in ODK Collect. Clicking 'launch' in ODK Co
 
 </p>
 
+For a full list of actions that Keppel supports, see [here](ACTIONS.md).
+
 ### ODK data downloads
 
 When you download your data CSV file from ODK Central, your fingerprint templates will be stored as plain text in line with other data from the form. From here you can either test them one at a time, or use a script to automate batch processing. 


### PR DESCRIPTION
Closes #18

As described in the issue, this adds a new `MULTI_MATCH` action:

```
uk.ac.lshtm.keppel.android.MULTI_MATCH(uk.ac.lshtm.keppel.android.iso_template_1=/data/finger_1,uk.ac.lshtm.keppel.android.iso_template_2=/data/finger_2)
```

This returns a single result which will be the highest score obtained from matching a scanned finger against `iso_template_1`, `iso_template_2` (and so on).