### PR TITLE
Show error when empty template is passed to `MATCH`

### DIFF
--- a/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
+++ b/Android/app/src/main/java/uk/ac/lshtm/keppel/android/scanning/IntentParser.kt
@@ -11,13 +11,14 @@ object IntentParser {
         val fast = odkExternalRequest.params[External.PARAM_FAST] == "true"
 
         return if (odkExternalRequest.action == External.ACTION_MATCH) {
-            val isoTemplate = odkExternalRequest.params[External.PARAM_ISO_TEMPLATE]
+            val isoTemplateParam = odkExternalRequest.params[External.PARAM_ISO_TEMPLATE]
+            val isoTemplates = if (!isoTemplateParam.isNullOrBlank()) {
+                listOf(isoTemplateParam)
+            } else {
+                emptyList()
+            }
 
-            Request.Match(
-                isoTemplate?.let { listOf(isoTemplate) } ?: emptyList(),
-                fast,
-                odkExternalRequest
-            )
+            Request.Match(isoTemplates, fast, odkExternalRequest)
         } else if (odkExternalRequest.action == External.ACTION_MULTI_MATCH) {
             var index = 1
             val isoTemplates = mutableListOf<String>()

--- a/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
+++ b/Android/app/src/test/java/uk/ac/lshtm/keppel/android/scanning/IntentParserTest.kt
@@ -35,6 +35,17 @@ class IntentParserTest {
     }
 
     @Test
+    fun `blank isoTemplate is not included for MATCH`() {
+        val intent = Intent().also {
+            it.action = External.ACTION_MATCH
+            it.putExtra(External.PARAM_ISO_TEMPLATE, "")
+        }
+
+        val request = IntentParser.parse(intent)
+        assertThat((request as Request.Match).isoTemplates, equalTo(emptyList()))
+    }
+
+    @Test
     fun `isoTemplates is empty when list of MULTI_MATCH templates does not start at 1`() {
         val intent = Intent().also {
             it.action = External.ACTION_MULTI_MATCH
@@ -58,7 +69,7 @@ class IntentParserTest {
     }
 
     @Test
-    fun `isoTemplates that are blank are filtered out`() {
+    fun `isoTemplates that are blank are filtered out for MULTI_MATCH`() {
         val intent = Intent().also {
             it.action = External.ACTION_MULTI_MATCH
             it.putExtra(External.paramIsoTemplate(1), "")


### PR DESCRIPTION
Improve handling of empty ISO templates being passed to `MATCH`.